### PR TITLE
get and nullhash, closes #595

### DIFF
--- a/holochain.go
+++ b/holochain.go
@@ -30,10 +30,10 @@ import (
 
 const (
 	// Version is the numeric version number of the holochain library
-	Version int = 20
+	Version int = 21
 
 	// VersionStr is the textual version number of the holochain library
-	VersionStr string = "20"
+	VersionStr string = "21"
 
 	// DefaultSendTimeout a time.Duration to wait by default for send to complete
 	DefaultSendTimeout = 3000 * time.Millisecond

--- a/jsribosome.go
+++ b/jsribosome.go
@@ -279,6 +279,7 @@ func (jsr *JSRibosome) validateEntry(fnName string, def *EntryDef, entry Entry, 
 
 const (
 	JSLibrary = `var HC={Version:` + `"` + VersionStr + "\"" +
+		`Error:{HashNotFound:undefined}` +
 		`,Status:{Live:` + StatusLiveVal +
 		`,Rejected:` + StatusRejectedVal +
 		`,Deleted:` + StatusDeletedVal +

--- a/jsribosome_test.go
+++ b/jsribosome_test.go
@@ -94,10 +94,10 @@ func TestNewJSRibosome(t *testing.T) {
 		So(err, ShouldBeNil)
 		z := v.(*JSRibosome)
 
-		_, err = z.Run("HC.Error.HashNotFound")
+		_, err = z.Run("HC.HashNotFound")
 		So(err, ShouldBeNil)
 		s, _ := z.lastResult.ToString()
-		So(s, ShouldEqual, "undefined")
+		So(s, ShouldEqual, "null")
 
 		_, err = z.Run("HC.Version")
 		So(err, ShouldBeNil)
@@ -656,8 +656,8 @@ func TestJSDHT(t *testing.T) {
 	defer CleanupTestChain(h, d)
 
 	hash, _ := NewHash("QmY8Mzg9F69e5P9AoQPYat6x5HEhc1TVGs11tmfNSzkqh2")
-	Convey("get should return hash not found if it doesn't exist", t, func() {
-		v, err := NewJSRibosome(h, &Zome{RibosomeType: JSRibosomeType, Code: fmt.Sprintf(`get("%s")==HC.NullHash;`, hash.String())})
+	Convey("get should return HC.HashNotFound if it doesn't exist", t, func() {
+		v, err := NewJSRibosome(h, &Zome{RibosomeType: JSRibosomeType, Code: fmt.Sprintf(`get("%s")===HC.HashNotFound;`, hash.String())})
 
 		So(err, ShouldBeNil)
 		z := v.(*JSRibosome)

--- a/jsribosome_test.go
+++ b/jsribosome_test.go
@@ -94,9 +94,14 @@ func TestNewJSRibosome(t *testing.T) {
 		So(err, ShouldBeNil)
 		z := v.(*JSRibosome)
 
-		_, err = z.Run("HC.Version")
+		_, err = z.Run("HC.Error.HashNotFound")
 		So(err, ShouldBeNil)
 		s, _ := z.lastResult.ToString()
+		So(s, ShouldEqual, "undefined")
+
+		_, err = z.Run("HC.Version")
+		So(err, ShouldBeNil)
+		s, _ = z.lastResult.ToString()
 		So(s, ShouldEqual, VersionStr)
 
 		_, err = z.Run("HC.Status.Deleted")
@@ -652,8 +657,13 @@ func TestJSDHT(t *testing.T) {
 
 	hash, _ := NewHash("QmY8Mzg9F69e5P9AoQPYat6x5HEhc1TVGs11tmfNSzkqh2")
 	Convey("get should return hash not found if it doesn't exist", t, func() {
-		_, err := NewJSRibosome(h, &Zome{RibosomeType: JSRibosomeType, Code: fmt.Sprintf(`get("%s");`, hash.String())})
-		So(err.Error(), ShouldEqual, `{"errorMessage":"hash not found","function":"get","name":"HolochainError","source":{}}`)
+		v, err := NewJSRibosome(h, &Zome{RibosomeType: JSRibosomeType, Code: fmt.Sprintf(`get("%s")==HC.NullHash;`, hash.String())})
+
+		So(err, ShouldBeNil)
+		z := v.(*JSRibosome)
+		x, err := z.lastResult.Export()
+		So(err, ShouldBeNil)
+		So(fmt.Sprintf("%v", x), ShouldEqual, `true`)
 	})
 
 	// add an entry onto the chain

--- a/service.go
+++ b/service.go
@@ -104,7 +104,7 @@ type ZomeFile struct {
 	RibosomeType string
 	BridgeFuncs  []string // functions in zome that can be bridged to by fromApp
 	BridgeTo     string   // dna Hash of toApp that this zome is a client of
-  	Config       map[string]interface{}
+	Config       map[string]interface{}
 	Entries      []EntryDefFile
 	Functions    []FunctionDef
 }
@@ -1767,7 +1767,7 @@ function asyncPing(message,id) {
 (defn confirmOdd [x]
   (letseq [h (makeHash "oddNumbers" x)
            r (get h)
-           err (hget r %error "")]
+           err (cond (hash? r) (hget r %error "") "found")]
      (cond (== err "") "true" "false")
   )
 )

--- a/zygosome.go
+++ b/zygosome.go
@@ -373,6 +373,7 @@ func (z *ZygoRibosome) Call(fn *FunctionDef, params interface{}) (result interfa
 // all Ribosome implementations.
 const (
 	ZygoLibrary = `(def HC_Version "` + VersionStr + `")` +
+		`(def HC_Error_HashNotFound nil)` +
 		`(def HC_Status_Live ` + StatusLiveVal + ")" +
 		`(def HC_Status_Rejected ` + StatusRejectedVal + ")" +
 		`(def HC_Status_Deleted ` + StatusDeletedVal + ")" +

--- a/zygosome.go
+++ b/zygosome.go
@@ -373,7 +373,7 @@ func (z *ZygoRibosome) Call(fn *FunctionDef, params interface{}) (result interfa
 // all Ribosome implementations.
 const (
 	ZygoLibrary = `(def HC_Version "` + VersionStr + `")` +
-		`(def HC_Error_HashNotFound nil)` +
+		`(def HC_HashNotFound nil)` +
 		`(def HC_Status_Live ` + StatusLiveVal + ")" +
 		`(def HC_Status_Rejected ` + StatusRejectedVal + ")" +
 		`(def HC_Status_Deleted ` + StatusDeletedVal + ")" +
@@ -1023,7 +1023,12 @@ func NewZygoRibosome(h *Holochain, zome *Zome) (n Ribosome, err error) {
 			}
 			var resultValue zygo.Sexp
 			resultValue = zygo.SexpNull
-			if err == nil {
+			if err == ErrHashNotFound {
+				// if the hash wasn't found this isn't actually an error
+				// so return nil which is the same as HC_HashNotFound
+				err = nil
+				return zygo.SexpNull, err
+			} else if err == nil {
 				getResp := r.(GetResp)
 				var entryStr string
 				var singleValueReturn bool

--- a/zygosome_test.go
+++ b/zygosome_test.go
@@ -72,7 +72,7 @@ func TestNewZygoRibosome(t *testing.T) {
 		So(err, ShouldBeNil)
 		z := v.(*ZygoRibosome)
 
-		_, err = z.Run("HC_Error_HashNotFound")
+		_, err = z.Run("HC_HashNotFound")
 		So(err, ShouldBeNil)
 		x := z.lastResult
 		So(x, ShouldEqual, zygo.SexpNull)
@@ -538,13 +538,13 @@ func TestZygoDHT(t *testing.T) {
 	defer CleanupTestChain(h, d)
 
 	hash, _ := NewHash("QmY8Mzg9F69e5P9AoQPYat6x5HEhc1TVGs11tmfNSzkqh2")
-	Convey("get should return hash not found if it doesn't exist", t, func() {
-		v, err := NewZygoRibosome(h, &Zome{RibosomeType: ZygoRibosomeType, Code: fmt.Sprintf(`(get "%s")`, hash.String())})
+	Convey("get should return HC_HashNotFound if it doesn't exist", t, func() {
+		v, err := NewZygoRibosome(h, &Zome{RibosomeType: ZygoRibosomeType, Code: fmt.Sprintf(`(== (get "%s") HC_HashNotFound)`, hash.String())})
 		So(err, ShouldBeNil)
 		z := v.(*ZygoRibosome)
-		r, err := z.lastResult.(*zygo.SexpHash).HashGet(z.env, z.env.MakeSymbol("error"))
+		r := z.lastResult.(*zygo.SexpBool)
 		So(err, ShouldBeNil)
-		So(r.(*zygo.SexpStr).S, ShouldEqual, "hash not found")
+		So(r.Val, ShouldEqual, true)
 	})
 	// add an entry onto the chain
 	hash = commit(h, "evenNumbers", "2")

--- a/zygosome_test.go
+++ b/zygosome_test.go
@@ -72,6 +72,11 @@ func TestNewZygoRibosome(t *testing.T) {
 		So(err, ShouldBeNil)
 		z := v.(*ZygoRibosome)
 
+		_, err = z.Run("HC_Error_HashNotFound")
+		So(err, ShouldBeNil)
+		x := z.lastResult
+		So(x, ShouldEqual, zygo.SexpNull)
+
 		_, err = z.Run("HC_Version")
 		So(err, ShouldBeNil)
 		s := z.lastResult.(*zygo.SexpStr).S


### PR DESCRIPTION
`get()` now returns HC.HashNotFound (which happens to be the javascript `null` value) instead of an error when the hash isn't found.