### PR TITLE
adapt any methods which have three return values

### DIFF
--- a/action.go
+++ b/action.go
@@ -113,13 +113,7 @@ func (h *Holochain) ValidateAction(a ValidatingAction, entryType string, pkg *Pa
 		}
 	}()
 
-	var z *Zome
 	def, err = h.GetEntryDef(entryType)
-	if err != nil {
-		return
-	}
-	// @TODO this makes the incorrect assumption that entry type strings are unique across zomes
-	z, err = h.GetZomeForEntryType(entryType)
 	if err != nil {
 		return
 	}
@@ -140,6 +134,12 @@ func (h *Holochain) ValidateAction(a ValidatingAction, entryType string, pkg *Pa
 		}
 
 		// run the action's app level validations
+		// @TODO this makes the incorrect assumption that entry type strings are unique across zomes
+		var z *Zome
+		z, err = h.GetZomeForEntryType(entryType)
+		if err != nil {
+			return
+		}
 		var n Ribosome
 		n, err = z.MakeRibosome(h)
 		if err != nil {

--- a/action_test.go
+++ b/action_test.go
@@ -124,7 +124,7 @@ func TestSysValidateEntry(t *testing.T) {
 		So(err, ShouldBeNil)
 	})
 
-	_, def, _ := h.GetEntryDef("rating")
+	def, _ := h.GetEntryDef("rating")
 
 	Convey("a nil entry is invalid", t, func() {
 		err := sysValidateEntry(h, def, nil, nil)
@@ -133,7 +133,7 @@ func TestSysValidateEntry(t *testing.T) {
 
 	Convey("validate on a schema based entry should check entry against the schema", t, func() {
 		profile := `{"firstName":"Eric"}` // missing required lastName
-		_, def, _ := h.GetEntryDef("profile")
+		def, _ := h.GetEntryDef("profile")
 
 		err := sysValidateEntry(h, def, &GobEntry{C: profile}, nil)
 		So(err, ShouldNotBeNil)
@@ -171,7 +171,7 @@ func TestSysValidateMod(t *testing.T) {
 	defer CleanupTestChain(h, d)
 
 	hash := commit(h, "evenNumbers", "2")
-	_, def, _ := h.GetEntryDef("evenNumbers")
+	def, _ := h.GetEntryDef("evenNumbers")
 
 	/* This is actually bogus because it assumes we have the entry type in our chain but
 	           might be in a different chain.
@@ -184,7 +184,7 @@ func TestSysValidateMod(t *testing.T) {
 
 	Convey("it should check that entry isn't linking ", t, func() {
 		a := NewModAction("rating", &GobEntry{}, hash)
-		_, ratingsDef, _ := h.GetEntryDef("rating")
+		ratingsDef, _ := h.GetEntryDef("rating")
 		err := a.SysValidation(h, ratingsDef, nil, []peer.ID{h.nodeID})
 		So(err.Error(), ShouldEqual, "Can't mod Links entry")
 	})
@@ -217,7 +217,7 @@ func TestSysValidateDel(t *testing.T) {
 	defer CleanupTestChain(h, d)
 
 	hash := commit(h, "evenNumbers", "2")
-	_, def, _ := h.GetEntryDef("evenNumbers")
+	def, _ := h.GetEntryDef("evenNumbers")
 
 	Convey("it should check that entry types match on del", t, func() {
 		a := NewDelAction("oddNumbers", DelEntry{Hash: hash})
@@ -227,7 +227,7 @@ func TestSysValidateDel(t *testing.T) {
 
 	Convey("it should check that entry isn't linking ", t, func() {
 		a := NewDelAction("rating", DelEntry{Hash: hash})
-		_, ratingsDef, _ := h.GetEntryDef("rating")
+		ratingsDef, _ := h.GetEntryDef("rating")
 		err := a.SysValidation(h, ratingsDef, nil, []peer.ID{h.nodeID})
 		So(err.Error(), ShouldEqual, "Can't del Links entry")
 	})

--- a/apptest/apptest.go
+++ b/apptest/apptest.go
@@ -502,7 +502,7 @@ func DoTest(h *Holochain, name string, i int, fixtures TestFixtures, t TestData,
 			b = StartBench(h)
 		}
 		if t.Raw {
-			n, _, err := h.MakeRibosome(t.Zome)
+			n, err := h.MakeRibosome(t.Zome)
 			if err != nil {
 				actualError = err
 			} else {

--- a/bridge.go
+++ b/bridge.go
@@ -63,7 +63,7 @@ func (h *Holochain) AddBridgeAsCallee(fromDNA Hash, appData string) (token strin
 
 	for zomeName, _ := range bridgeSpec {
 		var r Ribosome
-		r, _, err = h.MakeRibosome(zomeName)
+		r, err = h.MakeRibosome(zomeName)
 		if err != nil {
 			return
 		}
@@ -177,7 +177,7 @@ func (h *Holochain) AddBridgeAsCaller(toDNA Hash, token string, url string, appD
 	for _, z := range h.nucleus.dna.Zomes {
 		if z.BridgeTo.String() == toDNAStr {
 			var r Ribosome
-			r, _, err = h.MakeRibosome(z.Name)
+			r, err = h.MakeRibosome(z.Name)
 			if err != nil {
 				return
 			}

--- a/holochain.go
+++ b/holochain.go
@@ -589,7 +589,7 @@ func (h *Holochain) Walk(fn WalkerFn, entriesToo bool) (err error) {
 
 // GetEntryDef returns an EntryDef of the given name
 // @TODO this makes the incorrect assumption that entry type strings are unique across zomes
-func (h *Holochain) GetEntryDef(t string) (zome *Zome, d *EntryDef, err error) {
+func (h *Holochain) GetEntryDef(t string) (d *EntryDef, err error) {
 	if t == DNAEntryType {
 		d = DNAEntryDef
 		return
@@ -603,9 +603,24 @@ func (h *Holochain) GetEntryDef(t string) (zome *Zome, d *EntryDef, err error) {
 	for _, z := range h.nucleus.dna.Zomes {
 		d, err = z.GetEntryDef(t)
 		if err == nil {
+			return
+		}
+	}
+	return
+}
+
+// GetZomeForEntryType returns the zome for a given EntryType
+// @TODO this makes the incorrect assumption that entry type strings are unique across zomes
+func (h *Holochain) GetZomeForEntryType(t string) (zome *Zome, err error) {
+	for _, z := range h.nucleus.dna.Zomes {
+		_, err = z.GetEntryDef(t)
+		if err == nil {
 			zome = &z
 			return
 		}
+	}
+	if err == nil {
+		err = errors.New("no zome with entry type: " + t)
 	}
 	return
 }
@@ -620,7 +635,11 @@ func (h *Holochain) GetPrivateEntryDefs() (privateDefs []EntryDef) {
 
 // Call executes an exposed function
 func (h *Holochain) Call(zomeType string, function string, arguments interface{}, exposureContext string) (result interface{}, err error) {
-	n, z, err := h.MakeRibosome(zomeType)
+	n, err := h.MakeRibosome(zomeType)
+	if err != nil {
+		return
+	}
+	z, err := h.GetZome(zomeType)
 	if err != nil {
 		return
 	}
@@ -637,8 +656,8 @@ func (h *Holochain) Call(zomeType string, function string, arguments interface{}
 }
 
 // MakeRibosome creates a Ribosome object based on the zome type
-func (h *Holochain) MakeRibosome(t string) (r Ribosome, z *Zome, err error) {
-	z, err = h.GetZome(t)
+func (h *Holochain) MakeRibosome(t string) (r Ribosome, err error) {
+	z, err := h.GetZome(t)
 	if err != nil {
 		return
 	}
@@ -746,7 +765,7 @@ func (h *Holochain) SendAsync(proto int, to peer.ID, msg *Message, callback *Cal
 		response, err = h.Send(h.node.ctx, proto, to, msg, timeout)
 		if err == nil {
 			var r Ribosome
-			r, _, err := h.MakeRibosome(callback.zomeType)
+			r, err := h.MakeRibosome(callback.zomeType)
 			if err == nil {
 				switch t := response.(type) {
 				case AppMsg:
@@ -942,7 +961,7 @@ func (h *Holochain) Query(options *QueryOptions) (results []QueryResult, err err
 		var ok bool
 		def, ok = defs[header.Type]
 		if !ok {
-			_, def, err = h.GetEntryDef(header.Type)
+			def, err = h.GetEntryDef(header.Type)
 			if err != nil {
 				return
 			}

--- a/holochain_test.go
+++ b/holochain_test.go
@@ -454,13 +454,12 @@ func TestMakeRibosome(t *testing.T) {
 	defer CleanupTestChain(h, d)
 
 	Convey("it should fail if the zome isn't defined in the DNA", t, func() {
-		_, _, err := h.MakeRibosome("bogusZome")
+		_, err := h.MakeRibosome("bogusZome")
 		So(err.Error(), ShouldEqual, "unknown zome: bogusZome")
 	})
-	Convey("it should make a ribosome based on the type and return the zome def", t, func() {
-		v, zome, err := h.MakeRibosome("zySampleZome")
+	Convey("it should make a ribosome based on the type", t, func() {
+		v, err := h.MakeRibosome("zySampleZome")
 		So(err, ShouldBeNil)
-		So(zome.Name, ShouldEqual, "zySampleZome")
 		z := v.(*ZygoRibosome)
 		_, err = z.env.Run()
 		So(err, ShouldBeNil)
@@ -695,34 +694,29 @@ func TestGetEntryDef(t *testing.T) {
 	d, _, h := SetupTestChain("test")
 	defer CleanupTestDir(d)
 	Convey("it should fail on bad entry types", t, func() {
-		_, _, err := h.GetEntryDef("foobar")
+		_, err := h.GetEntryDef("foobar")
 		So(err, ShouldBeError)
 		So(err.Error(), ShouldEqual, "no definition for entry type: foobar")
 	})
 	Convey("it should get entry definitions", t, func() {
-		zome, def, err := h.GetEntryDef("evenNumbers")
+		def, err := h.GetEntryDef("evenNumbers")
 		So(err, ShouldBeNil)
-		So(zome.Name, ShouldEqual, "zySampleZome")
 		So(fmt.Sprintf("%v", def), ShouldEqual, "&{evenNumbers zygo public  <nil>}")
 	})
 	Convey("it should get sys entry definitions", t, func() {
-		zome, def, err := h.GetEntryDef(DNAEntryType)
+		def, err := h.GetEntryDef(DNAEntryType)
 		So(err, ShouldBeNil)
-		So(zome, ShouldBeNil)
 		So(def, ShouldEqual, DNAEntryDef)
-		zome, def, err = h.GetEntryDef(AgentEntryType)
+		def, err = h.GetEntryDef(AgentEntryType)
 		So(err, ShouldBeNil)
-		So(zome, ShouldBeNil)
 		So(def, ShouldEqual, AgentEntryDef)
-		zome, def, err = h.GetEntryDef(KeyEntryType)
+		def, err = h.GetEntryDef(KeyEntryType)
 		So(err, ShouldBeNil)
-		So(zome, ShouldBeNil)
 		So(def, ShouldEqual, KeyEntryDef)
 	})
 	Convey("it should get private entry definition", t, func() {
-		zome, def, err := h.GetEntryDef("privateData")
+		def, err := h.GetEntryDef("privateData")
 		So(err, ShouldBeNil)
-		So(zome, ShouldNotBeNil)
 		So(def, ShouldNotBeNil)
 	})
 }
@@ -731,7 +725,7 @@ func TestGetPrivateEntryDefs(t *testing.T) {
 	d, _, h := SetupTestChain("test")
 	defer CleanupTestDir(d)
 	Convey("it should contain only private entry definition", t, func() {
-		_, privateData, _ := h.GetEntryDef("privateData")
+		privateData, _ := h.GetEntryDef("privateData")
 		privateDefs := h.GetPrivateEntryDefs()
 		So(len(privateDefs), ShouldEqual, 1)
 		So(privateDefs[0].Name, ShouldEqual, privateData.Name)

--- a/jsribosome.go
+++ b/jsribosome.go
@@ -431,7 +431,7 @@ func jsProcessArgs(jsr *JSRibosome, args []Arg, oArgs []otto.Value) (err error) 
 			if err != nil {
 				return err
 			}
-			_, def, err := jsr.h.GetEntryDef(entryType)
+			def, err := jsr.h.GetEntryDef(entryType)
 			if err != nil {
 				return err
 			}
@@ -528,7 +528,7 @@ type fnData struct {
 }
 
 func makeOttoObjectFromGetResp(h *Holochain, jsr *JSRibosome, getResp *GetResp) (result interface{}, err error) {
-	_, def, err := h.GetEntryDef(getResp.EntryType)
+	def, err := h.GetEntryDef(getResp.EntryType)
 	if err != nil {
 		return
 	}
@@ -842,7 +842,7 @@ func NewJSRibosome(h *Holochain, zome *Zome) (n Ribosome, err error) {
 						var ok bool
 						def, ok = defs[qresult.Header.Type]
 						if !ok {
-							_, def, err = h.GetEntryDef(qresult.Header.Type)
+							def, err = h.GetEntryDef(qresult.Header.Type)
 							if err != nil {
 								return
 							}
@@ -1138,7 +1138,7 @@ func NewJSRibosome(h *Holochain, zome *Zome) (n Ribosome, err error) {
 							l += `,EntryType:"` + jsSanitizeString(th.EntryType) + `"`
 							l += `,Source:"` + jsSanitizeString(th.Source) + `"`
 							var def *EntryDef
-							_, def, err = h.GetEntryDef(th.EntryType)
+							def, err = h.GetEntryDef(th.EntryType)
 							if err != nil {
 								break
 							}

--- a/jsribosome_test.go
+++ b/jsribosome_test.go
@@ -610,11 +610,15 @@ func TestJSExposeCall(t *testing.T) {
 	d, _, h := PrepareTestChain("test")
 	defer CleanupTestChain(h, d)
 
-	v, zome, err := h.MakeRibosome("jsSampleZome")
+	v, err := h.MakeRibosome("jsSampleZome")
 	if err != nil {
 		panic(err)
 	}
 	z := v.(*JSRibosome)
+	zome, err := h.GetZome("jsSampleZome")
+	if err != nil {
+		panic(err)
+	}
 	Convey("should allow calling exposed STRING based functions", t, func() {
 		cater, _ := zome.GetFunctionDef("testStrFn1")
 		result, err := z.Call(cater, "fish \"zippy\"")

--- a/zygosome.go
+++ b/zygosome.go
@@ -483,7 +483,7 @@ func zyProcessArgs(z *ZygoRibosome, args []Arg, zyArgs []zygo.Sexp) (err error) 
 			// don't have to do checking because the previous time through the loop
 			// should have done it
 			entryType := zyArgs[i-1].(*zygo.SexpStr).S
-			_, def, err := z.h.GetEntryDef(entryType)
+			def, err := z.h.GetEntryDef(entryType)
 			if err != nil {
 				return err
 			}
@@ -923,7 +923,7 @@ func NewZygoRibosome(h *Holochain, zome *Zome) (n Ribosome, err error) {
 					var ok bool
 					def, ok = defs[result.Header.Type]
 					if !ok {
-						_, def, err = h.GetEntryDef(result.Header.Type)
+						def, err = h.GetEntryDef(result.Header.Type)
 						if err != nil {
 							return zygo.SexpNull, err
 						}

--- a/zygosome_test.go
+++ b/zygosome_test.go
@@ -502,12 +502,15 @@ func TestZygoExposeCall(t *testing.T) {
 	d, _, h := PrepareTestChain("test")
 	defer CleanupTestChain(h, d)
 
-	v, zome, err := h.MakeRibosome("zySampleZome")
+	v, err := h.MakeRibosome("zySampleZome")
 	if err != nil {
 		panic(err)
 	}
 	z := v.(*ZygoRibosome)
-
+	zome, err := h.GetZome("zySampleZome")
+	if err != nil {
+		panic(err)
+	}
 	Convey("should allow calling exposed STRING based functions", t, func() {
 		cater, _ := zome.GetFunctionDef("testStrFn1")
 		result, err := z.Call(cater, "fish \"zippy\"")


### PR DESCRIPTION
To follow convention, each method should have one, maybe two return
values. the first the result, the second an optional error

since almost all of the places in the code where these methods are
called, one out of the two return values goes unused anyways, the
function signature should just remove it. in the cases where those other
methods need it, they can call the method directly that was being used
to fetch that result