### PR TITLE
fixes and tests for sign and verifySignature, closes #612

### DIFF
--- a/action.go
+++ b/action.go
@@ -384,11 +384,11 @@ func (a *ActionGetBridges) Do(h *Holochain) (response interface{}, err error) {
 // Sign
 
 type ActionSign struct {
-	doc []byte
+	data []byte
 }
 
-func NewSignAction(doc []byte) *ActionSign {
-	a := ActionSign{doc: doc}
+func NewSignAction(data []byte) *ActionSign {
+	a := ActionSign{data: data}
 	return &a
 }
 
@@ -397,16 +397,16 @@ func (a *ActionSign) Name() string {
 }
 
 func (a *ActionSign) Args() []Arg {
-	return []Arg{{Name: "doc", Type: StringArg}}
+	return []Arg{{Name: "data", Type: StringArg}}
 }
 
 func (a *ActionSign) Do(h *Holochain) (response interface{}, err error) {
-	var b []byte
-	b, err = h.Sign(a.doc)
+	var sig Signature
+	sig, err = h.Sign(a.data)
 	if err != nil {
 		return
 	}
-	response = b
+	response = sig.B58String()
 	return
 }
 

--- a/action_test.go
+++ b/action_test.go
@@ -4,6 +4,7 @@ import (
 	// "fmt"
 	"fmt"
 	. "github.com/Holochain/holochain-proto/hash"
+	b58 "github.com/jbenet/go-base58"
 	ic "github.com/libp2p/go-libp2p-crypto"
 	peer "github.com/libp2p/go-libp2p-peer"
 	. "github.com/smartystreets/goconvey/convey"
@@ -338,5 +339,40 @@ func TestActionGetLocal(t *testing.T) {
 		So(err, ShouldBeNil)
 		getResp := rsp.(GetResp)
 		So(getResp.Entry.Content().(string), ShouldEqual, "31415")
+	})
+}
+
+func TestActionSigning(t *testing.T) {
+	d, _, h := PrepareTestChain("test")
+	defer CleanupTestChain(h, d)
+
+	privKey := h.agent.PrivKey()
+	sig, err := privKey.Sign([]byte("3"))
+	if err != nil {
+		panic(err)
+	}
+
+	var b58sig string
+	Convey("sign action should return a b58 encoded signature", t, func() {
+		result, err := NewSignAction([]byte("3")).Do(h)
+		So(err, ShouldBeNil)
+		b58sig = result.(string)
+
+		So(b58sig, ShouldEqual, b58.Encode(sig))
+	})
+
+	var pubKeyBytes []byte
+	pubKeyBytes, err = ic.MarshalPublicKey(h.agent.PubKey())
+	if err != nil {
+		panic(err)
+	}
+	pubKey := b58.Encode(pubKeyBytes)
+	Convey("verify signture action should test a signature", t, func() {
+		result, err := NewVerifySignatureAction(b58sig, string([]byte("3")), pubKey).Do(h)
+		So(err, ShouldBeNil)
+		So(result.(bool), ShouldBeTrue)
+		result, err = NewVerifySignatureAction(b58sig, string([]byte("34")), pubKey).Do(h)
+		So(err, ShouldBeNil)
+		So(result.(bool), ShouldBeFalse)
 	})
 }

--- a/holochain.go
+++ b/holochain.go
@@ -870,17 +870,14 @@ func (h *Holochain) Send(basectx context.Context, proto int, to peer.ID, message
 	return
 }
 
-//Sign uses the agent' private key to sign the contents of doc
-func (h *Holochain) Sign(doc []byte) (sig []byte, err error) {
+// Sign uses the agent's private key to sign the contents of data
+func (h *Holochain) Sign(data []byte) (signature Signature, err error) {
 	privKey := h.agent.PrivKey()
-	sig, err = privKey.Sign(doc)
-	if err != nil {
-		return
-	}
+	signature.S, err = privKey.Sign(data)
 	return
 }
 
-//VerifySignature uses the signature, data(doc) and signatory's public key to Verify the sign in contents of doc
+// VerifySignature uses the signature, data and the given public key to Verify the data was signed by holder of that key
 func (h *Holochain) VerifySignature(signature Signature, data string, pubKey ic.PubKey) (matches bool, err error) {
 
 	matches, err = pubKey.Verify([]byte(data), signature.S)

--- a/holochain_test.go
+++ b/holochain_test.go
@@ -738,6 +738,29 @@ func TestGetPrivateEntryDefs(t *testing.T) {
 	})
 }
 
+func TestSigning(t *testing.T) {
+	d, _, h := SetupTestChain("test")
+	defer CleanupTestDir(d)
+	Convey("a user should be able to sign and verify data", t, func() {
+		privKey := h.agent.PrivKey()
+		sig, err := privKey.Sign([]byte("3"))
+		if err != nil {
+			panic(err)
+		}
+		signature, err := h.Sign([]byte("3"))
+		So(err, ShouldBeNil)
+		So(string(signature.S), ShouldEqual, string(sig))
+
+		matched, err := h.VerifySignature(signature, string([]byte("3")), h.agent.PubKey())
+		So(err, ShouldBeNil)
+		So(matched, ShouldBeTrue)
+
+		matched, err = h.VerifySignature(signature, string([]byte("32")), h.agent.PubKey())
+		So(err, ShouldBeNil)
+		So(matched, ShouldBeFalse)
+	})
+}
+
 //func TestDNADefaults(t *testing.T) {
 //	h, err := DecodeDNA(strings.NewReader( [[Zomes]]`
 //Name = "test"

--- a/jsribosome.go
+++ b/jsribosome.go
@@ -624,17 +624,17 @@ func NewJSRibosome(h *Holochain, zome *Zome) (n Ribosome, err error) {
 			a: &ActionSign{},
 			fn: func(args []Arg, _a ArgsAction, call otto.FunctionCall) (result otto.Value, err error) {
 				a := _a.(*ActionSign)
-				a.doc = []byte(args[0].value.(string))
+				a.data = []byte(args[0].value.(string))
 				var r interface{}
 				r, err = a.Do(h)
 				if err != nil {
 					return
 				}
-				var signature []byte
+				var b58sig string
 				if r != nil {
-					signature = r.([]byte)
+					b58sig = r.(string)
 				}
-				result, _ = jsr.vm.ToValue(string(signature))
+				result, _ = jsr.vm.ToValue(b58sig)
 				return
 			},
 		},

--- a/jsribosome_test.go
+++ b/jsribosome_test.go
@@ -209,7 +209,7 @@ func TestNewJSRibosome(t *testing.T) {
 
 		})
 
-		// Sign - this methord signs the data that is passed with the user's privKey and returns the signed data
+		// Sign - this function signs the data that is passed with the user's privKey and returns the signed data
 		Convey("sign", func() {
 			d, _, h := PrepareTestChain("test")
 			defer CleanupTestChain(h, d)
@@ -224,16 +224,16 @@ func TestNewJSRibosome(t *testing.T) {
 			_, err = z.Run(`sign("3")`)
 			So(err, ShouldBeNil)
 			//z := v.(*JSRibosome)
-			So(z.lastResult.String(), ShouldEqual, string(sig))
+			So(z.lastResult.String(), ShouldEqual, b58.Encode(sig))
 			//test2
 			sig, err = privKey.Sign([]byte("{\"firstName\":\"jackT\",\"lastName\":\"hammer\"}"))
 			_, err = z.Run(`sign('{"firstName":"jackT","lastName":"hammer"}')`)
 			So(err, ShouldBeNil)
-			So(z.lastResult.String(), ShouldEqual, string(sig))
+			So(z.lastResult.String(), ShouldEqual, b58.Encode(sig))
 		})
 
-		//Verifying signature of a perticular user
-		// sig will be signed by the user and We will verifySignature i.e verify if the uses we know signed it
+		//Verifying signature of a particular user
+		// sig will be signed by the user and We will verifySignature i.e verify if the user we know signed it
 		Convey("verifySignature", func() {
 			d, _, h := PrepareTestChain("test")
 			defer CleanupTestChain(h, d)
@@ -252,6 +252,11 @@ func TestNewJSRibosome(t *testing.T) {
 			_, err = z.Run(fmt.Sprintf(`verifySignature("%s","%s","%s")`, b58.Encode((sig)), "3", b58.Encode(pubKeyBytes)))
 			So(err, ShouldBeNil)
 			So(z.lastResult.String(), ShouldEqual, "true")
+
+			_, err = z.Run(fmt.Sprintf(`verifySignature(sign("3"),"%s","%s")`, "3", b58.Encode(pubKeyBytes)))
+			So(err, ShouldBeNil)
+			So(z.lastResult.String(), ShouldEqual, "true")
+
 			//verifySignature function FAILURE Condition
 			_, err = z.Run(fmt.Sprintf(`verifySignature("%s","%s","%s")`, b58.Encode(sig), "34", b58.Encode(pubKeyBytes)))
 			So(err, ShouldBeNil)


### PR DESCRIPTION
sign and verifySign didn't have good tests.  Also it turns out sign was returning a binary string.  Now these are all b58 encoded to match the encoding coming for headers in #610 