### PR TITLE
WIP: added headers sys entry type, #610

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -9,6 +9,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	b58 "github.com/jbenet/go-base58"
 	ic "github.com/libp2p/go-libp2p-crypto"
 	peer "github.com/libp2p/go-libp2p-peer"
 	"io"
@@ -38,6 +39,7 @@ type Agent interface {
 	GenKeys(seed io.Reader) error
 	PrivKey() ic.PrivKey
 	PubKey() ic.PubKey
+	EncodePubKey() (string, error)
 	NodeID() (peer.ID, string, error)
 	AgentEntry(revocation Revocation) (AgentEntry, error)
 }
@@ -65,6 +67,16 @@ func (a *LibP2PAgent) PrivKey() ic.PrivKey {
 
 func (a *LibP2PAgent) PubKey() ic.PubKey {
 	return a.pub
+}
+
+func (a *LibP2PAgent) EncodePubKey() (b58pk string, err error) {
+	var pk []byte
+	pk, err = ic.MarshalPublicKey(a.pub)
+	if err != nil {
+		return
+	}
+	b58pk = b58.Encode(pk)
+	return
 }
 
 func (a *LibP2PAgent) GenKeys(seed io.Reader) (err error) {
@@ -100,7 +112,7 @@ func (a *LibP2PAgent) AgentEntry(revocation Revocation) (entry AgentEntry, err e
 			return
 		}
 	}
-	entry.PublicKey, err = ic.MarshalPublicKey(a.PubKey())
+	entry.PublicKey, err = a.EncodePubKey()
 	if err != nil {
 		return
 	}

--- a/dht.go
+++ b/dht.go
@@ -18,7 +18,6 @@ import (
 	"sync"
 
 	. "github.com/Holochain/holochain-proto/hash"
-	ic "github.com/libp2p/go-libp2p-crypto"
 	peer "github.com/libp2p/go-libp2p-peer"
 	"github.com/tidwall/buntdb"
 )
@@ -277,13 +276,12 @@ func (dht *DHT) putKey(agent Agent) (err error) {
 	if err != nil {
 		return
 	}
-
-	var pubKey []byte
-	pubKey, err = ic.MarshalPublicKey(agent.PubKey())
+	var pubKey string
+	pubKey, err = agent.EncodePubKey()
 	if err != nil {
 		return
 	}
-	if err = dht.put(dht.h.node.NewMessage(PUT_REQUEST, PutReq{H: keyHash}), KeyEntryType, keyHash, nodeID, pubKey, StatusLive); err != nil {
+	if err = dht.put(dht.h.node.NewMessage(PUT_REQUEST, PutReq{H: keyHash}), KeyEntryType, keyHash, nodeID, []byte(pubKey), StatusLive); err != nil {
 		return
 	}
 	return

--- a/dht_test.go
+++ b/dht_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	. "github.com/Holochain/holochain-proto/hash"
-	ic "github.com/libp2p/go-libp2p-crypto"
+	b58 "github.com/jbenet/go-base58"
 	peer "github.com/libp2p/go-libp2p-peer"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/tidwall/buntdb"
@@ -67,14 +67,14 @@ func TestSetupDHT(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(status, ShouldEqual, StatusLive)
 		So(et, ShouldEqual, KeyEntryType)
-		pubKey, err := ic.MarshalPublicKey(h.agent.PubKey())
-		So(string(data), ShouldEqual, string(pubKey))
+		pubKey, err := h.agent.EncodePubKey()
+		So(string(data), ShouldEqual, pubKey)
 
 		data, et, _, status, err = h.dht.get(keyHash, StatusDefault, GetMaskDefault)
 		So(err, ShouldBeNil)
 		So(status, ShouldEqual, StatusLive)
 
-		So(string(data), ShouldEqual, string(pubKey))
+		So(string(data), ShouldEqual, pubKey)
 	})
 }
 
@@ -344,13 +344,14 @@ func TestDHTSend(t *testing.T) {
 		So(err, ShouldBeNil)
 		resp := r.(GetResp)
 		ae, _ := h.agent.AgentEntry(nil)
-		So(fmt.Sprintf("%v", resp.Entry.Content()), ShouldEqual, fmt.Sprintf("%v", ae))
+		a, _ := ae.ToJSON()
+		So(resp.Entry.Content().(string), ShouldEqual, a)
 
 		msg = h.node.NewMessage(GET_REQUEST, GetReq{H: HashFromPeerID(h.nodeID), StatusMask: StatusLive})
 		r, err = h.dht.send(nil, h.nodeID, msg)
 		So(err, ShouldBeNil)
 		resp = r.(GetResp)
-		So(fmt.Sprintf("%v", resp.Entry.Content()), ShouldEqual, fmt.Sprintf("%v", ae.PublicKey))
+		So(resp.Entry.Content().(string), ShouldEqual, ae.PublicKey)
 
 		// for now this is an error because we presume everyone has the DNA.
 		// once we implement dna changes, this needs to be changed
@@ -493,7 +494,7 @@ func TestActionReceiver(t *testing.T) {
 		r, err = ActionReceiver(h, m)
 		So(err, ShouldBeNil)
 		resp = r.(GetResp)
-		So(resp.Entry.C, ShouldBeNil)
+		So(resp.Entry.C, ShouldEqual, nil)
 		So(resp.EntryType, ShouldEqual, "evenNumbers")
 
 		m = h.node.NewMessage(GET_REQUEST, GetReq{H: hash, GetMask: GetMaskEntry + GetMaskEntryType})
@@ -507,7 +508,7 @@ func TestActionReceiver(t *testing.T) {
 		r, err = ActionReceiver(h, m)
 		So(err, ShouldBeNil)
 		resp = r.(GetResp)
-		So(resp.Entry.C, ShouldBeNil)
+		So(resp.Entry.C, ShouldEqual, nil)
 		So(fmt.Sprintf("%v", resp.Sources), ShouldEqual, fmt.Sprintf("[%v]", h.nodeIDStr))
 		So(resp.EntryType, ShouldEqual, "evenNumbers") // you allways get the entry type even if not in getmask at this level (ActionReceiver) because we have to be able to look up the definition to interpret the contents
 
@@ -770,7 +771,7 @@ func TestDHTDump(t *testing.T) {
 		So(dump, ShouldContainSubstring, "DHT entries:")
 		So(dump, ShouldContainSubstring, fmt.Sprintf("Hash--%s (status 1)", h.nodeIDStr))
 		pk, _ := h.agent.PubKey().Bytes()
-		So(dump, ShouldContainSubstring, fmt.Sprintf("Value: %s", string(pk)))
+		So(dump, ShouldContainSubstring, fmt.Sprintf("Value: %s", string(b58.Encode(pk))))
 		So(dump, ShouldContainSubstring, fmt.Sprintf("Sources: %s", h.nodeIDStr))
 
 		So(dump, ShouldContainSubstring, fmt.Sprintf("Linked to: %s with tag %s", reviewHash, "4stars"))
@@ -875,17 +876,18 @@ func TestDHTMultiNode(t *testing.T) {
 				req := GetReq{H: HashFromPeerID(h1.nodeID), StatusMask: options.StatusMask, GetMask: options.GetMask}
 				response, err := NewGetAction(req, &options).Do(h2)
 				if err != nil {
-					//          fmt.Printf("FAIL   : %v couldn't get from %v err: %err\n", h2.nodeID, h1.nodeID, err)
+					fmt.Printf("FAIL   : %v couldn't get from %v err: %err\n", h2.nodeID, h1.nodeID, err)
 				} else {
-					responseStr := fmt.Sprintf("%v", response)
-					pk, _ := h1.agent.PubKey().Bytes()
-					expectedResponseStr := fmt.Sprintf("{{%v} %s [] }", pk, `%%key`)
+					e := response.(GetResp).Entry
+					responseStr := fmt.Sprintf("%v", e.Content())
+					pk, _ := h1.agent.EncodePubKey()
+					expectedResponseStr := pk
 					if responseStr == expectedResponseStr {
 						connections += 1
-						//            fmt.Printf("SUCCESS: %v got from          %v\n", h2.nodeID, h1.nodeID)
+						//fmt.Printf("SUCCESS: %v got from          %v\n", h2.nodeID, h1.nodeID)
 					} else {
-						//            fmt.Printf("Expected:%s\n", expectedResponseStr)
-						//            fmt.Printf("Got     :%s\n", responseStr)
+						//fmt.Printf("Expected:%s\n", expectedResponseStr)
+						//fmt.Printf("Got     :%s\n", responseStr)
 					}
 				}
 			}

--- a/entry.go
+++ b/entry.go
@@ -21,9 +21,10 @@ const (
 
 	// System defined entry types
 
-	DNAEntryType   = SysEntryTypePrefix + "dna"
-	AgentEntryType = SysEntryTypePrefix + "agent"
-	KeyEntryType   = VirtualEntryTypePrefix + "key" // virtual entry type, not actually on the chain
+	DNAEntryType     = SysEntryTypePrefix + "dna"
+	AgentEntryType   = SysEntryTypePrefix + "agent"
+	HeadersEntryType = SysEntryTypePrefix + "header"
+	KeyEntryType     = VirtualEntryTypePrefix + "key" // virtual entry type, not actually on the chain
 
 	// Entry type formats
 
@@ -81,6 +82,94 @@ type EntryDef struct {
 var DNAEntryDef = &EntryDef{Name: DNAEntryType, DataFormat: DataFormatSysDNA}
 var AgentEntryDef = &EntryDef{Name: AgentEntryType, DataFormat: DataFormatSysAgent}
 var KeyEntryDef = &EntryDef{Name: KeyEntryType, DataFormat: DataFormatSysKey}
+
+const (
+	HeadersEntrySchema = `
+{
+  "$id": "http://example.com/example.json",
+  "type": "array",
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "items": {
+    "$id": "http://example.com/example.json/items",
+    "type": "object",
+    "properties": {
+      "Header": {
+        "$id": "http://example.com/example.json/items/properties/Header",
+        "type": "object",
+        "properties": {
+          "Type": {
+            "$id": "http://example.com/example.json/items/properties/Header/properties/Type",
+            "type": "string",
+            "title": "The Type Schema ",
+            "default": "",
+            "examples": [
+              "evenNumbers"
+            ]
+          },
+          "Time": {
+            "$id": "http://example.com/example.json/items/properties/Header/properties/Time",
+            "type": "string",
+            "title": "The Time Schema ",
+            "default": "",
+            "examples": [
+              "1969-12-31 19:00:01.000000001 -0500 EST"
+            ]
+          },
+          "EntryLink": {
+            "$id": "http://example.com/example.json/items/properties/Header/properties/EntryLink",
+            "type": "string",
+            "title": "The Entrylink Schema ",
+            "default": "",
+            "examples": [
+              "QmNiCwBNA8MWDADTFVq1BonUEJbS2SvjAoNkZZrhEwcuU2"
+            ]
+          },
+          "HeaderLink": {
+            "$id": "http://example.com/example.json/items/properties/Header/properties/HeaderLink",
+            "type": "string",
+            "title": "The Headerlink Schema ",
+            "default": "",
+            "examples": [
+              "QmNiCwBNA8MWDADTFVq1BonUEJbS2SvjAoNkZZrhEwcuUi"
+            ]
+          },
+          "TypeLink": {
+            "$id": "http://example.com/example.json/items/properties/Header/properties/TypeLink",
+            "type": "string",
+            "title": "The Typelink Schema ",
+            "default": "",
+            "examples": [
+              "1"
+            ]
+          },
+          "Signature": {
+            "$id": "http://example.com/example.json/items/properties/Header/properties/Signature",
+            "type": "string",
+            "title": "The Signature Schema ",
+            "default": "",
+            "examples": [
+              "3eDinUfqsX4V2iuwFvFNSwyy4KEugYj6DPpssjrAsabkVvozBrWrLJRuA9AXhiN8R3MzZvyLfW2BV8zKDevSDiVR"
+            ]
+          }
+        }
+      },
+      "Role": {
+        "$id": "http://example.com/example.json/items/properties/Role",
+        "type": "string",
+        "title": "The Role Schema ",
+        "default": "",
+        "examples": [
+          "someRole"
+        ]
+      }
+    }
+  }
+}
+`
+)
+
+var HeadersEntryDef = &EntryDef{Name: HeadersEntryType, DataFormat: DataFormatJSON, Sharing: Public, Schema: HeadersEntrySchema}
 
 // Entry describes serialization and deserialziation of entry data
 type Entry interface {

--- a/entry_test.go
+++ b/entry_test.go
@@ -113,3 +113,28 @@ func TestMarshalEntry(t *testing.T) {
 		So(fmt.Sprintf("%v", ne), ShouldEqual, fmt.Sprintf("%v", &e))
 	})
 }
+
+func TestAgentEntryToJSON(t *testing.T) {
+	a := AgentIdentity("zippy@someemail.com")
+	a1, _ := NewAgent(LibP2P, a, MakeTestSeed(""))
+	pk, _ := a1.EncodePubKey()
+	ae := AgentEntry{
+		Identity:  a,
+		PublicKey: pk,
+	}
+
+	var j string
+	var err error
+	Convey("it should convert to JSON", t, func() {
+		j, err = ae.ToJSON()
+		So(err, ShouldBeNil)
+		So(j, ShouldEqual, `{"Identity":"zippy@someemail.com","Revocation":"","PublicKey":"4XTTM4Lf8pAWo6dfra223t4ZK7gjAjFA49VdwrC1wVHQqb8nH"}`)
+	})
+
+	Convey("it should convert from JSON", t, func() {
+		ae2, err := AgentEntryFromJSON(j)
+		So(err, ShouldBeNil)
+		So(ae2, ShouldResemble, ae)
+	})
+
+}

--- a/header.go
+++ b/header.go
@@ -31,7 +31,7 @@ type StatusChange struct {
 type Header struct {
 	Type       string
 	Time       time.Time
-	HeaderLink Hash // link to previous headerq
+	HeaderLink Hash // link to previous header
 	EntryLink  Hash // link to entry
 	TypeLink   Hash // link to header of previous header of this type
 	Sig        Signature

--- a/holochain.go
+++ b/holochain.go
@@ -405,7 +405,12 @@ func (h *Holochain) AddAgentEntry(revocation Revocation) (headerHash, agentHash 
 	if err != nil {
 		return
 	}
-	e := GobEntry{C: entry}
+	var j string
+	j, err = entry.ToJSON()
+	if err != nil {
+		return
+	}
+	e := GobEntry{C: j}
 
 	var agentHeader *Header
 	headerHash, agentHeader, err = h.NewEntry(time.Now(), AgentEntryType, &e)

--- a/holochain.go
+++ b/holochain.go
@@ -590,21 +590,22 @@ func (h *Holochain) Walk(fn WalkerFn, entriesToo bool) (err error) {
 // GetEntryDef returns an EntryDef of the given name
 // @TODO this makes the incorrect assumption that entry type strings are unique across zomes
 func (h *Holochain) GetEntryDef(t string) (zome *Zome, d *EntryDef, err error) {
-	if t == DNAEntryType {
+	switch t {
+	case DNAEntryType:
 		d = DNAEntryDef
-		return
-	} else if t == AgentEntryType {
+	case AgentEntryType:
 		d = AgentEntryDef
-		return
-	} else if t == KeyEntryType {
+	case KeyEntryType:
 		d = KeyEntryDef
-		return
-	}
-	for _, z := range h.nucleus.dna.Zomes {
-		d, err = z.GetEntryDef(t)
-		if err == nil {
-			zome = &z
-			return
+	case HeadersEntryType:
+		d = HeadersEntryDef
+	default:
+		for _, z := range h.nucleus.dna.Zomes {
+			d, err = z.GetEntryDef(t)
+			if err == nil {
+				zome = &z
+				return
+			}
 		}
 	}
 	return

--- a/holochain_test.go
+++ b/holochain_test.go
@@ -340,9 +340,11 @@ func TestAddAgentEntry(t *testing.T) {
 		entry, _, err := h.chain.GetEntry(agentHash)
 		So(err, ShouldBeNil)
 
-		var a = entry.Content().(AgentEntry)
+		a, err := AgentEntryFromJSON(entry.Content().(string))
+		So(err, ShouldBeNil)
+
 		So(a.Identity, ShouldEqual, h.agent.Identity())
-		pk, _ := h.agent.PubKey().Bytes()
+		pk, _ := h.agent.EncodePubKey()
 		So(string(a.PublicKey), ShouldEqual, string(pk))
 		So(string(a.Revocation), ShouldEqual, "some revocation data")
 	})
@@ -371,9 +373,9 @@ func TestGenChain(t *testing.T) {
 		entry, _, err := h.chain.GetEntry(hdr.EntryLink)
 		So(err, ShouldBeNil)
 		header = *hdr
-		var a = entry.Content().(AgentEntry)
+		a, _ := AgentEntryFromJSON(entry.Content().(string))
 		So(a.Identity, ShouldEqual, h.agent.Identity())
-		pk, _ := h.agent.PubKey().Bytes()
+		pk, _ := h.agent.EncodePubKey()
 		So(string(a.PublicKey), ShouldEqual, string(pk))
 		So(string(a.Revocation), ShouldEqual, "")
 	})

--- a/holochain_test.go
+++ b/holochain_test.go
@@ -718,6 +718,10 @@ func TestGetEntryDef(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(zome, ShouldBeNil)
 		So(def, ShouldEqual, KeyEntryDef)
+		zome, def, err = h.GetEntryDef(HeadersEntryType)
+		So(err, ShouldBeNil)
+		So(zome, ShouldBeNil)
+		So(def, ShouldEqual, HeadersEntryDef)
 	})
 	Convey("it should get private entry definition", t, func() {
 		zome, def, err := h.GetEntryDef("privateData")

--- a/jsribosome.go
+++ b/jsribosome.go
@@ -537,7 +537,7 @@ func makeOttoObjectFromGetResp(h *Holochain, jsr *JSRibosome, getResp *GetResp) 
 		code := `(` + json + `)`
 		result, err = jsr.vm.Object(code)
 	} else {
-		result = getResp.Entry.Content()
+		result = getResp.Entry.Content().(string)
 	}
 	return
 }
@@ -854,13 +854,6 @@ func NewJSRibosome(h *Holochain, zome *Zome) (n Ribosome, err error) {
 							fallthrough
 						case DataFormatJSON:
 							entryCode = fmt.Sprintf(`JSON.parse("%s")`, jsSanitizeString(r.(string)))
-						case DataFormatSysAgent:
-							var j []byte
-							j, err = json.Marshal(r.(AgentEntry))
-							if err != nil {
-								return
-							}
-							entryCode = fmt.Sprintf(`JSON.parse("%s")`, jsSanitizeString(string(j)))
 						default:
 							err = errors.New("data format not implemented: " + def.DataFormat)
 							return
@@ -1144,13 +1137,11 @@ func NewJSRibosome(h *Holochain, zome *Zome) (n Ribosome, err error) {
 								entry = th.E
 							case DataFormatRawZygo:
 								fallthrough
+							case DataFormatSysKey:
+								// key is a b58 encoded public key so the entry is just the string value
+								fallthrough
 							case DataFormatString:
 								entry = `"` + jsSanitizeString(th.E) + `"`
-							case DataFormatSysKey:
-								//TODO: this is broken, should be some real key format.
-								entry = fmt.Sprintf("%v", th.E)
-							case DataFormatSysAgent:
-								fallthrough
 							case DataFormatLinks:
 								fallthrough
 							case DataFormatJSON:

--- a/jsribosome.go
+++ b/jsribosome.go
@@ -279,6 +279,12 @@ func (jsr *JSRibosome) validateEntry(fnName string, def *EntryDef, entry Entry, 
 
 const (
 	JSLibrary = `var HC={Version:` + `"` + VersionStr + "\"" +
+		`SysEntryType:{` +
+		`DNA:"` + DNAEntryType + `",` +
+		`Agent:"` + AgentEntryType + `",` +
+		`Key:"` + KeyEntryType + `",` +
+		`Headers:"` + HeadersEntryType + `"` +
+		`}` +
 		`HashNotFound:null` +
 		`,Status:{Live:` + StatusLiveVal +
 		`,Rejected:` + StatusRejectedVal +

--- a/jsribosome.go
+++ b/jsribosome.go
@@ -1147,6 +1147,7 @@ func NewJSRibosome(h *Holochain, zome *Zome) (n Ribosome, err error) {
 							case DataFormatString:
 								entry = `"` + jsSanitizeString(th.E) + `"`
 							case DataFormatSysKey:
+								//TODO: this is broken, should be some real key format.
 								entry = fmt.Sprintf("%v", th.E)
 							case DataFormatSysAgent:
 								fallthrough

--- a/jsribosome_test.go
+++ b/jsribosome_test.go
@@ -99,6 +99,26 @@ func TestNewJSRibosome(t *testing.T) {
 		s, _ := z.lastResult.ToString()
 		So(s, ShouldEqual, "null")
 
+		_, err = z.Run("HC.SysEntryType.DNA")
+		So(err, ShouldBeNil)
+		s, _ = z.lastResult.ToString()
+		So(s, ShouldEqual, DNAEntryType)
+
+		_, err = z.Run("HC.SysEntryType.Agent")
+		So(err, ShouldBeNil)
+		s, _ = z.lastResult.ToString()
+		So(s, ShouldEqual, AgentEntryType)
+
+		_, err = z.Run("HC.SysEntryType.Key")
+		So(err, ShouldBeNil)
+		s, _ = z.lastResult.ToString()
+		So(s, ShouldEqual, KeyEntryType)
+
+		_, err = z.Run("HC.SysEntryType.Headers")
+		So(err, ShouldBeNil)
+		s, _ = z.lastResult.ToString()
+		So(s, ShouldEqual, HeadersEntryType)
+
 		_, err = z.Run("HC.Version")
 		So(err, ShouldBeNil)
 		s, _ = z.lastResult.ToString()

--- a/jsribosome_test.go
+++ b/jsribosome_test.go
@@ -391,7 +391,7 @@ func TestJSQuery(t *testing.T) {
 		ShouldLog(h.nucleus.alog, func() {
 			_, err := z.Run(`debug(query({Constrain:{EntryTypes:["%agent"]}}))`)
 			So(err, ShouldBeNil)
-		}, `[{"Identity":"Herbert \u003ch@bert.com\u003e","PublicKey":"CAESIHLUfxjdoEfk8byjsBR+FXxYpYrFTviSBf2BbC0boylT","Revocation":null}]`)
+		}, `[{"Identity":"Herbert \u003ch@bert.com\u003e","PublicKey":"4XTTM8sJEQD5zMLT1gtu2ogshwg5AdUPNhJRbLvs77gsVtQQi","Revocation":""}]`)
 
 		_, err := z.Run(`debug(query({Constrain:{EntryTypes:["%dna"]}}))`)
 		So(err.Error(), ShouldEqual, `{"errorMessage":"data format not implemented: _DNA","function":"query","name":"HolochainError","source":{}}`)
@@ -687,11 +687,11 @@ func TestJSDHT(t *testing.T) {
 		ShouldLog(h.nucleus.alog, func() {
 			_, err := NewJSRibosome(h, &Zome{RibosomeType: JSRibosomeType, Code: fmt.Sprintf(`debug(get("%s"));`, h.agentHash.String())})
 			So(err, ShouldBeNil)
-		}, `{"Identity":"Herbert \u003ch@bert.com\u003e","PublicKey":[8,1,18,32,114,212,127,24,221,160,71,228,241,188,163,176,20,126,21,124,88,165,138,197,78,248,146,5,253,129,108,45,27,163,41,83],"Revocation":[]}`)
+		}, `{"Identity":"Herbert \u003ch@bert.com\u003e","PublicKey":"4XTTM8sJEQD5zMLT1gtu2ogshwg5AdUPNhJRbLvs77gsVtQQi","Revocation":""}`)
 		ShouldLog(h.nucleus.alog, func() {
 			_, err := NewJSRibosome(h, &Zome{RibosomeType: JSRibosomeType, Code: fmt.Sprintf(`debug(get("%s"));`, h.nodeID.Pretty())})
 			So(err, ShouldBeNil)
-		}, `[8,1,18,32,114,212,127,24,221,160,71,228,241,188,163,176,20,126,21,124,88,165,138,197,78,248,146,5,253,129,108,45,27,163,41,83]`)
+		}, "4XTTM8sJEQD5zMLT1gtu2ogshwg5AdUPNhJRbLvs77gsVtQQi")
 	})
 
 	Convey("get should return entry type", t, func() {
@@ -798,17 +798,17 @@ func TestJSDHT(t *testing.T) {
 		z := v.(*JSRibosome)
 		So(z.lastResult.Class(), ShouldEqual, "Array")
 		links, _ := z.lastResult.Export()
-		l0 := links.([]map[string]interface{})[1]
-		l1 := links.([]map[string]interface{})[0]
+		l0 := links.([]map[string]interface{})[0]
+		l1 := links.([]map[string]interface{})[1]
 		So(l1["Hash"], ShouldEqual, h.agentHash.String())
 		lp := l1["Entry"].(map[string]interface{})
 		So(fmt.Sprintf("%v", lp["Identity"]), ShouldEqual, "Herbert <h@bert.com>")
-		So(fmt.Sprintf("%v", lp["PublicKey"]), ShouldEqual, "CAESIHLUfxjdoEfk8byjsBR+FXxYpYrFTviSBf2BbC0boylT")
+		So(fmt.Sprintf("%v", lp["PublicKey"]), ShouldEqual, "4XTTM8sJEQD5zMLT1gtu2ogshwg5AdUPNhJRbLvs77gsVtQQi")
 		So(l1["EntryType"], ShouldEqual, AgentEntryType)
 		So(l1["Source"], ShouldEqual, h.nodeIDStr)
 
 		So(l0["Hash"], ShouldEqual, h.nodeIDStr)
-		So(fmt.Sprintf("%v", l0["Entry"]), ShouldEqual, "CAESIHLUfxjdoEfk8byjsBR+FXxYpYrFTviSBf2BbC0boylT")
+		So(fmt.Sprintf("%v", l0["Entry"]), ShouldEqual, "4XTTM8sJEQD5zMLT1gtu2ogshwg5AdUPNhJRbLvs77gsVtQQi")
 		So(l0["EntryType"], ShouldEqual, KeyEntryType)
 	})
 
@@ -903,7 +903,7 @@ func TestJSDHT(t *testing.T) {
 	})
 
 	Convey("updateAgent function should commit a new agent entry", t, func() {
-		oldPubKey, _ := h.agent.PubKey().Bytes()
+		oldPubKey, _ := h.agent.EncodePubKey()
 		v, err := NewJSRibosome(h, &Zome{RibosomeType: JSRibosomeType,
 			Code: fmt.Sprintf(`updateAgent({Identity:"new identity"})`)})
 		So(err, ShouldBeNil)
@@ -914,11 +914,12 @@ func TestJSDHT(t *testing.T) {
 		So(header.Type, ShouldEqual, AgentEntryType)
 		So(newAgentHash, ShouldEqual, header.EntryLink.String())
 		So(h.agent.Identity(), ShouldEqual, "new identity")
-		newPubKey, _ := h.agent.PubKey().Bytes()
+		newPubKey, _ := h.agent.EncodePubKey()
 		So(fmt.Sprintf("%v", newPubKey), ShouldEqual, fmt.Sprintf("%v", oldPubKey))
 		entry, _, _ := h.chain.GetEntry(header.EntryLink)
-		So(entry.Content().(AgentEntry).Identity, ShouldEqual, "new identity")
-		So(fmt.Sprintf("%v", entry.Content().(AgentEntry).PublicKey), ShouldEqual, fmt.Sprintf("%v", oldPubKey))
+		a, _ := AgentEntryFromJSON(entry.Content().(string))
+		So(a.Identity, ShouldEqual, "new identity")
+		So(fmt.Sprintf("%v", a.PublicKey), ShouldEqual, fmt.Sprintf("%v", oldPubKey))
 	})
 
 	Convey("updateAgent function with revoke option should commit a new agent entry and mark key as modified on DHT", t, func() {
@@ -938,23 +939,24 @@ func TestJSDHT(t *testing.T) {
 		header := h.chain.Top()
 		So(header.Type, ShouldEqual, AgentEntryType)
 		So(newAgentHash, ShouldEqual, header.EntryLink.String())
-		newPubKey, _ := h.agent.PubKey().Bytes()
+		newPubKey, _ := h.agent.EncodePubKey()
 		So(fmt.Sprintf("%v", newPubKey), ShouldNotEqual, fmt.Sprintf("%v", oldPubKey))
 		entry, _, _ := h.chain.GetEntry(header.EntryLink)
 		revocation := &SelfRevocation{}
-		revocation.Unmarshal(entry.Content().(AgentEntry).Revocation)
+		a, _ := AgentEntryFromJSON(entry.Content().(string))
+		revocation.Unmarshal(a.Revocation)
 
 		w, _ := NewSelfRevocationWarrant(revocation)
 		payload, _ := w.Property("payload")
 
 		So(string(payload.([]byte)), ShouldEqual, "some revocation data")
-		So(fmt.Sprintf("%v", entry.Content().(AgentEntry).PublicKey), ShouldEqual, fmt.Sprintf("%v", newPubKey))
+		So(fmt.Sprintf("%v", a.PublicKey), ShouldEqual, fmt.Sprintf("%v", newPubKey))
 
 		// the new Key should be available on the DHT
 		newKey, _ := NewHash(h.nodeIDStr)
 		data, _, _, _, err := h.dht.get(newKey, StatusDefault, GetMaskDefault)
 		So(err, ShouldBeNil)
-		So(string(data), ShouldEqual, string(newPubKey))
+		So(string(data), ShouldEqual, newPubKey)
 
 		// the old key should be marked as Modifed and we should get the new hash as the data
 		data, _, _, _, err = h.dht.get(oldKey, StatusDefault, GetMaskDefault)

--- a/revocation.go
+++ b/revocation.go
@@ -14,8 +14,8 @@ import (
 
 type Revocation interface {
 	Verify() error
-	Marshal() ([]byte, error)
-	Unmarshal([]byte) error
+	Marshal() (string, error)
+	Unmarshal(string) error
 }
 
 var SelfRevocationDoesNotVerify = errors.New("self revocation does not verify")
@@ -73,13 +73,17 @@ func (r *SelfRevocation) getNewKey() (key ic.PubKey, err error) {
 	return
 }
 
-func (r *SelfRevocation) Marshal() (data []byte, err error) {
-	data, err = json.Marshal(r)
+func (r *SelfRevocation) Marshal() (data string, err error) {
+	var j []byte
+	j, err = json.Marshal(r)
+	if err == nil {
+		data = string(j)
+	}
 	return
 }
 
-func (r *SelfRevocation) Unmarshal(data []byte) (err error) {
-	err = json.Unmarshal(data, r)
+func (r *SelfRevocation) Unmarshal(data string) (err error) {
+	err = json.Unmarshal([]byte(data), r)
 	return
 }
 

--- a/service.go
+++ b/service.go
@@ -174,11 +174,12 @@ func IsInitialized(root string) bool {
 // and writes them out to configuration files in the root path (making the
 // directory if necessary)
 func Init(root string, identity AgentIdentity, seed io.Reader) (service *Service, err error) {
+	//TODO this is in the wrong place it should be where HeadersEntryDef gets initialized
 	if HeadersEntryDef.validator == nil {
-		//TODO this is in the wrong place it should be where HeadersEntryDef gets initialized
-
 		err = HeadersEntryDef.BuildJSONSchemaValidatorFromString(HeadersEntryDef.Schema)
-		fmt.Printf("SETUP validator:%p", HeadersEntryDef.validator)
+	}
+	if AgentEntryDef.validator == nil {
+		err = AgentEntryDef.BuildJSONSchemaValidatorFromString(AgentEntryDef.Schema)
 	}
 
 	err = os.MkdirAll(root, os.ModePerm)

--- a/service.go
+++ b/service.go
@@ -174,6 +174,13 @@ func IsInitialized(root string) bool {
 // and writes them out to configuration files in the root path (making the
 // directory if necessary)
 func Init(root string, identity AgentIdentity, seed io.Reader) (service *Service, err error) {
+	if HeadersEntryDef.validator == nil {
+		//TODO this is in the wrong place it should be where HeadersEntryDef gets initialized
+
+		err = HeadersEntryDef.BuildJSONSchemaValidatorFromString(HeadersEntryDef.Schema)
+		fmt.Printf("SETUP validator:%p", HeadersEntryDef.validator)
+	}
+
 	err = os.MkdirAll(root, os.ModePerm)
 	if err != nil {
 		return

--- a/validate_test.go
+++ b/validate_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	. "github.com/Holochain/holochain-proto/hash"
-	ic "github.com/libp2p/go-libp2p-crypto"
 	. "github.com/smartystreets/goconvey/convey"
 	"strings"
 	"testing"
@@ -197,12 +196,12 @@ func TestGetValidationResponse(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(resp.Type, ShouldEqual, KeyEntryType)
 
-		pk, err := ic.MarshalPublicKey(h.agent.PubKey())
+		pk, err := h.agent.EncodePubKey()
 		if err != nil {
 			panic(err)
 		}
 
-		So(fmt.Sprintf("%v", resp.Entry.Content()), ShouldEqual, fmt.Sprintf("%v", pk))
+		So(string(resp.Entry.Content().(string)), ShouldEqual, pk)
 		So(fmt.Sprintf("%v", resp.Package), ShouldEqual, fmt.Sprintf("%v", Package{}))
 	})
 

--- a/validate_test.go
+++ b/validate_test.go
@@ -205,6 +205,21 @@ func TestGetValidationResponse(t *testing.T) {
 		So(fmt.Sprintf("%v", resp.Entry.Content()), ShouldEqual, fmt.Sprintf("%v", pk))
 		So(fmt.Sprintf("%v", resp.Package), ShouldEqual, fmt.Sprintf("%v", Package{}))
 	})
+
+	Convey("headers entry type should return empty package with the entry", t, func() {
+		hd := h.Chain().Top()
+		j, _ := hd.ToJSON()
+		entryStr := fmt.Sprintf(`[{"Header":%s,"Role":"someRole"}]`, j)
+		hash := commit(h, HeadersEntryType, entryStr)
+		hd = h.Chain().Top()
+		e := &GobEntry{C: entryStr}
+		a := NewPutAction(HeadersEntryType, e, hd)
+		resp, err := h.GetValidationResponse(a, hash)
+		So(err, ShouldBeNil)
+		So(resp.Type, ShouldEqual, HeadersEntryType)
+		So(fmt.Sprintf("%v", resp.Entry.Content()), ShouldEqual, entryStr)
+		So(fmt.Sprintf("%v", resp.Package), ShouldEqual, fmt.Sprintf("%v", Package{}))
+	})
 }
 
 func TestMakeValidatePackage(t *testing.T) {

--- a/warrant.go
+++ b/warrant.go
@@ -146,11 +146,15 @@ func (w *SelfRevocationWarrant) Property(key string) (value interface{}, err err
 }
 
 func (w *SelfRevocationWarrant) Encode() (data []byte, err error) {
-	data, err = w.Revocation.Marshal()
+	var rev string
+	rev, err = w.Revocation.Marshal()
+	if err == nil {
+		data = []byte(rev)
+	}
 	return
 }
 
 func (w *SelfRevocationWarrant) Decode(data []byte) (err error) {
-	err = w.Revocation.Unmarshal(data)
+	err = w.Revocation.Unmarshal(string(data))
 	return
 }

--- a/warrant_test.go
+++ b/warrant_test.go
@@ -58,7 +58,8 @@ func TestSelfRevocationWarrant(t *testing.T) {
 		header := h.chain.Top()
 		entry, _, _ := h.chain.GetEntry(header.EntryLink)
 		revocation := &SelfRevocation{}
-		revocation.Unmarshal(entry.Content().(AgentEntry).Revocation)
+		a, _ := AgentEntryFromJSON(entry.Content().(string))
+		revocation.Unmarshal(a.Revocation)
 		w, err := NewSelfRevocationWarrant(revocation)
 
 		parties, err := w.Parties()

--- a/zygosome.go
+++ b/zygosome.go
@@ -929,7 +929,6 @@ func NewZygoRibosome(h *Holochain, zome *Zome) (n Ribosome, err error) {
 						}
 						defs[result.Header.Type] = def
 					}
-					r := result.Entry.Content()
 					var content string
 					switch def.DataFormat {
 					case DataFormatRawZygo:
@@ -942,12 +941,6 @@ func NewZygoRibosome(h *Holochain, zome *Zome) (n Ribosome, err error) {
 						fallthrough
 					case DataFormatJSON:
 						content = result.Entry.Content().(string)
-					case DataFormatSysAgent:
-						j, err := json.Marshal(r.(AgentEntry))
-						if err != nil {
-							return zygo.SexpNull, err
-						}
-						content = string(j)
 					default:
 						return zygo.SexpNull, fmt.Errorf("data format not implemented: %s", def.DataFormat)
 					}

--- a/zygosome_test.go
+++ b/zygosome_test.go
@@ -283,7 +283,7 @@ func TestZygoQuery(t *testing.T) {
 		ShouldLog(h.nucleus.alog, func() {
 			_, err := z.Run(`(debug (str (query (hash Constrain: (hash EntryTypes: ["%agent"])))))`)
 			So(err, ShouldBeNil)
-		}, `["{\"Identity\":\"Herbert \\u003ch@bert.com\\u003e\",\"Revocation\":null,\"PublicKey\":\"CAESIHLUfxjdoEfk8byjsBR+FXxYpYrFTviSBf2BbC0boylT\"}"]`)
+		}, `["{\"Identity\":\"Herbert \\u003ch@bert.com\\u003e\",\"Revocation\":\"\",\"PublicKey\":\"4XTTM8sJEQD5zMLT1gtu2ogshwg5AdUPNhJRbLvs77gsVtQQi\"}"]`)
 	})
 }
 func TestZygoGenesis(t *testing.T) {
@@ -562,7 +562,7 @@ func TestZygoDHT(t *testing.T) {
 		ShouldLog(h.nucleus.alog, func() {
 			_, err := NewZygoRibosome(h, &Zome{RibosomeType: ZygoRibosomeType, Code: fmt.Sprintf(`(debug (get "%s"))`, h.agentHash.String())})
 			So(err, ShouldBeNil)
-		}, `{"result":"{\"Identity\":\"Herbert \\u003ch@bert.com\\u003e\",\"Revocation\":null,\"PublicKey\":\"CAESIHLUfxjdoEfk8byjsBR+FXxYpYrFTviSBf2BbC0boylT\"}"}`)
+		}, `{"result":"\"{\\\"Identity\\\":\\\"Herbert \\\\u003ch@bert.com\\\\u003e\\\",\\\"Revocation\\\":\\\"\\\",\\\"PublicKey\\\":\\\"4XTTM8sJEQD5zMLT1gtu2ogshwg5AdUPNhJRbLvs77gsVtQQi\\\"}\""}`)
 	})
 
 	Convey("get should return entry type", t, func() {
@@ -704,7 +704,7 @@ func TestZygoDHT(t *testing.T) {
 	})
 
 	Convey("updateAgent function should commit a new agent entry", t, func() {
-		oldPubKey, _ := h.agent.PubKey().Bytes()
+		oldPubKey, _ := h.agent.EncodePubKey()
 		v, err := NewZygoRibosome(h, &Zome{RibosomeType: ZygoRibosomeType,
 			Code: fmt.Sprintf(`(updateAgent (hash Identity:"new identity"))`)})
 		So(err, ShouldBeNil)
@@ -715,15 +715,16 @@ func TestZygoDHT(t *testing.T) {
 		So(header.Type, ShouldEqual, AgentEntryType)
 		So(newAgentHash, ShouldEqual, header.EntryLink.String())
 		So(h.agent.Identity(), ShouldEqual, "new identity")
-		newPubKey, _ := h.agent.PubKey().Bytes()
+		newPubKey, _ := h.agent.EncodePubKey()
 		So(fmt.Sprintf("%v", newPubKey), ShouldEqual, fmt.Sprintf("%v", oldPubKey))
 		entry, _, _ := h.chain.GetEntry(header.EntryLink)
-		So(entry.Content().(AgentEntry).Identity, ShouldEqual, "new identity")
-		So(fmt.Sprintf("%v", entry.Content().(AgentEntry).PublicKey), ShouldEqual, fmt.Sprintf("%v", oldPubKey))
+		a, _ := AgentEntryFromJSON(entry.Content().(string))
+		So(a.Identity, ShouldEqual, "new identity")
+		So(fmt.Sprintf("%v", a.PublicKey), ShouldEqual, fmt.Sprintf("%v", oldPubKey))
 	})
 
 	Convey("updateAgent function with revoke option should commit a new agent entry and mark key as modified on DHT", t, func() {
-		oldPubKey, _ := h.agent.PubKey().Bytes()
+		oldPubKey, _ := h.agent.EncodePubKey()
 		oldPeer := h.nodeID
 		oldKey, _ := NewHash(h.nodeIDStr)
 		oldAgentHash := h.agentHash
@@ -740,23 +741,25 @@ func TestZygoDHT(t *testing.T) {
 		header := h.chain.Top()
 		So(header.Type, ShouldEqual, AgentEntryType)
 		So(newAgentHash, ShouldEqual, header.EntryLink.String())
-		newPubKey, _ := h.agent.PubKey().Bytes()
+		newPubKey, _ := h.agent.EncodePubKey()
 		So(fmt.Sprintf("%v", newPubKey), ShouldNotEqual, fmt.Sprintf("%v", oldPubKey))
 		entry, _, _ := h.chain.GetEntry(header.EntryLink)
 		revocation := &SelfRevocation{}
-		revocation.Unmarshal(entry.Content().(AgentEntry).Revocation)
+		a, _ := AgentEntryFromJSON(entry.Content().(string))
+		revocation.Unmarshal(a.Revocation)
 
 		w, _ := NewSelfRevocationWarrant(revocation)
 		payload, _ := w.Property("payload")
 
 		So(string(payload.([]byte)), ShouldEqual, "some revocation data")
-		So(fmt.Sprintf("%v", entry.Content().(AgentEntry).PublicKey), ShouldEqual, fmt.Sprintf("%v", newPubKey))
+		So(fmt.Sprintf("%v", a.PublicKey), ShouldEqual, fmt.Sprintf("%v", newPubKey))
 
 		// the new Key should be available on the DHT
 		newKey, _ := NewHash(h.nodeIDStr)
 		data, _, _, _, err := h.dht.get(newKey, StatusDefault, GetMaskDefault)
 		So(err, ShouldBeNil)
-		So(string(data), ShouldEqual, string(newPubKey))
+		newpk, _ := h.agent.EncodePubKey()
+		So(string(data), ShouldEqual, newpk)
 
 		// the old key should be marked as Modifed and we should get the new hash as the data
 		data, _, _, _, err = h.dht.get(oldKey, StatusDefault, GetMaskDefault)


### PR DESCRIPTION
this implements a headers system entry type that validates an entry that should look like this:

`[{"Header":{"Type":"someType","Time":"2018-03-15 19:30:05.740445736 -0400 EDT","EntryLink":"QmeLEGdTHwM4XYGggePJAYXLx968GiuiNooU1p7fa8T8zd","HeaderLink":"QmWr1C3CeX12iZz98JGhzfsvfQpif29Ptwe86miZ9N9snU","TypeLink":"1","Signature":"StwmRCJtj9Ymjdo7ws8ZeNdmEi2GZzNdtbubT8MZBfxpXWQDLtQPDZWeSA2qHTsVtyN7tZCrYTeWmeCdcoYe197"},"Role":"someRole"}]`

i.e. its an array of Header/Role pairs.

There's a bunch of other cleanup in this branch to get to this place.  Key and Agent entry types are now simple JSON strings so that you can interpret them when you get them back from packages.  And everything matches so it should be usable with `verifySignature()` too.

Also you can access system entry type through these constants: 
`HC.SysEntryType.DNA`, `HC.SysEntryType.Agent`, `HC.SysEntryType.Key`, & `HC.SysEntryType.Headers`