### PR TITLE
validate functions now allow returning a string failed reason, closes #530

### DIFF
--- a/action_test.go
+++ b/action_test.go
@@ -36,7 +36,7 @@ func TestValidateAction(t *testing.T) {
 		entry := &GobEntry{C: "1"}
 		a := NewCommitAction("evenNumbers", entry)
 		_, err = h.ValidateAction(a, a.entryType, nil, []peer.ID{h.nodeID})
-		So(err, ShouldEqual, ValidationFailedErr)
+		So(IsValidationFailedErr(err), ShouldBeTrue)
 	})
 
 	// these test the sys type cases
@@ -73,14 +73,14 @@ func TestSysValidateEntry(t *testing.T) {
 	Convey("key entry should be a public key", t, func() {
 		e := &GobEntry{}
 		err := sysValidateEntry(h, KeyEntryDef, e, nil)
-		So(err, ShouldEqual, ValidationFailedErr)
+		So(IsValidationFailedErr(err), ShouldBeTrue)
 		e.C = []byte{1, 2, 3}
 		err = sysValidateEntry(h, KeyEntryDef, e, nil)
-		So(err, ShouldEqual, ValidationFailedErr)
+		So(IsValidationFailedErr(err), ShouldBeTrue)
 
 		e.C = []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6}
 		err = sysValidateEntry(h, KeyEntryDef, e, nil)
-		So(err, ShouldEqual, ValidationFailedErr)
+		So(IsValidationFailedErr(err), ShouldBeTrue)
 
 		pk, _ := ic.MarshalPublicKey(h.agent.PubKey())
 		e.C = pk
@@ -91,33 +91,33 @@ func TestSysValidateEntry(t *testing.T) {
 	Convey("an agent entry should have the correct structure as defined", t, func() {
 		e := &GobEntry{}
 		err := sysValidateEntry(h, AgentEntryDef, e, nil)
-		So(err, ShouldEqual, ValidationFailedErr)
+		So(IsValidationFailedErr(err), ShouldBeTrue)
 
 		// bad agent entry (empty)
 		e.C = AgentEntry{}
 		err = sysValidateEntry(h, AgentEntryDef, e, nil)
-		So(err, ShouldEqual, ValidationFailedErr)
+		So(IsValidationFailedErr(err), ShouldBeTrue)
 
 		ae, _ := h.agent.AgentEntry(nil)
 		// bad public key
 		ae.PublicKey = nil
 		e.C = ae
 		err = sysValidateEntry(h, AgentEntryDef, e, nil)
-		So(err, ShouldEqual, ValidationFailedErr)
+		So(IsValidationFailedErr(err), ShouldBeTrue)
 
 		ae, _ = h.agent.AgentEntry(nil)
 		// bad public key
 		ae.PublicKey = []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6}
 		e.C = ae
 		err = sysValidateEntry(h, AgentEntryDef, e, nil)
-		So(err, ShouldEqual, ValidationFailedErr)
+		So(IsValidationFailedErr(err), ShouldBeTrue)
 
 		ae, _ = h.agent.AgentEntry(nil)
 		// bad revocation
 		ae.Revocation = []byte{1, 2, 3}
 		e.C = ae
 		err = sysValidateEntry(h, AgentEntryDef, e, nil)
-		So(err, ShouldEqual, ValidationFailedErr)
+		So(IsValidationFailedErr(err), ShouldBeTrue)
 
 		ae, _ = h.agent.AgentEntry(nil)
 		e.C = ae
@@ -129,7 +129,8 @@ func TestSysValidateEntry(t *testing.T) {
 
 	Convey("a nil entry is invalid", t, func() {
 		err := sysValidateEntry(h, def, nil, nil)
-		So(err.Error(), ShouldEqual, "nil entry invalid")
+		So(IsValidationFailedErr(err), ShouldBeTrue)
+		So(err.Error(), ShouldEqual, "Validation Failed: nil entry invalid")
 	})
 
 	Convey("validate on a schema based entry should check entry against the schema", t, func() {
@@ -137,8 +138,8 @@ func TestSysValidateEntry(t *testing.T) {
 		_, def, _ := h.GetEntryDef("profile")
 
 		err := sysValidateEntry(h, def, &GobEntry{C: profile}, nil)
-		So(err, ShouldNotBeNil)
-		So(err.Error(), ShouldEqual, "validator profile failed: object property 'lastName' is required")
+		So(IsValidationFailedErr(err), ShouldBeTrue)
+		So(err.Error(), ShouldEqual, "Validation Failed: validator profile failed: object property 'lastName' is required")
 	})
 
 	Convey("validate on a links entry should fail if not formatted correctly", t, func() {

--- a/holochain_test.go
+++ b/holochain_test.go
@@ -483,7 +483,7 @@ func TestCall(t *testing.T) {
 		So(result.(string), ShouldEqual, ph.String())
 
 		_, err = h.Call("zySampleZome", "addEven", "41", ZOME_EXPOSURE)
-		So(err.Error(), ShouldEqual, "Error calling 'commit': Validation Failed")
+		So(err.Error(), ShouldEqual, "Error calling 'commit': Validation Failed: 41 is not even")
 	})
 	Convey("it should fail calls to functions not exposed to the given context", t, func() {
 		_, err := h.Call("zySampleZome", "testStrFn1", "arg1 arg2", PUBLIC_EXPOSURE)

--- a/jsribosome.go
+++ b/jsribosome.go
@@ -241,18 +241,26 @@ func (jsr *JSRibosome) runValidate(fnName string, code string) (err error) {
 		return
 	}
 	if v.IsBoolean() {
-		if v.IsBoolean() {
-			var b bool
-			b, err = v.ToBoolean()
-			if err != nil {
-				return
-			}
-			if !b {
-				err = ValidationFailedErr
-			}
+		var b bool
+		b, err = v.ToBoolean()
+		if err != nil {
+			return
 		}
+		if !b {
+			err = ValidationFailed()
+		}
+	} else if v.IsString() {
+		var s string
+		s, err = v.ToString()
+		if err != nil {
+			return
+		}
+		if s != "" {
+			err = ValidationFailed(s)
+		}
+
 	} else {
-		err = fmt.Errorf("%s should return boolean, got: %v", fnName, v)
+		err = fmt.Errorf("%s should return boolean or string, got: %v", fnName, v)
 	}
 	return
 }

--- a/jsribosome_test.go
+++ b/jsribosome_test.go
@@ -516,7 +516,7 @@ foo
 		a := NewCommitAction("oddNumbers", &GobEntry{C: "cow"})
 		a.header = &hdr
 		err = v.ValidateAction(a, &d, nil, nil)
-		So(err, ShouldEqual, ValidationFailedErr)
+		So(IsValidationFailedErr(err), ShouldBeTrue)
 
 		a = NewCommitAction("oddNumbers", &GobEntry{C: "fish"})
 		a.header = &hdr
@@ -530,7 +530,7 @@ foo
 		a := NewCommitAction("oddNumbers", &GobEntry{C: "\"cow\""})
 		a.header = &hdr
 		err = v.ValidateAction(a, &d, nil, nil)
-		So(err, ShouldEqual, ValidationFailedErr)
+		So(IsValidationFailedErr(err), ShouldBeTrue)
 
 		a = NewCommitAction("oddNumbers", &GobEntry{C: "\"fish\""})
 		a.header = &hdr
@@ -544,7 +544,7 @@ foo
 		a := NewCommitAction("evenNumbers", &GobEntry{C: `{"data":"cow"}`})
 		a.header = &hdr
 		err = v.ValidateAction(a, &d, nil, nil)
-		So(err, ShouldEqual, ValidationFailedErr)
+		So(IsValidationFailedErr(err), ShouldBeTrue)
 
 		a = NewCommitAction("evenNumbers", &GobEntry{C: `{"data":"fish"}`})
 		a.header = &hdr

--- a/ribosome.go
+++ b/ribosome.go
@@ -43,9 +43,23 @@ const (
 	BridgeTo      = 1
 	BridgeFromStr = "0"
 	BridgeToStr   = "1"
+
+	ValidationFailedErrMsg = "Validation Failed"
 )
 
-var ValidationFailedErr = errors.New("Validation Failed")
+var ValidationFailedErr = errors.New(ValidationFailedErrMsg)
+
+// ValidationFailed creates a validation failed error message
+func ValidationFailed(msgs ...string) error {
+	if len(msgs) == 0 {
+		return ValidationFailedErr
+	}
+	return errors.New(ValidationFailedErrMsg + ": " + strings.Join(msgs, `, `))
+}
+
+func IsValidationFailedErr(err error) bool {
+	return strings.HasPrefix(err.Error(), ValidationFailedErrMsg)
+}
 
 // FunctionDef holds the name and calling type of an DNA exposed function
 type FunctionDef struct {

--- a/ribosome_test.go
+++ b/ribosome_test.go
@@ -31,3 +31,18 @@ func TestValidExposure(t *testing.T) {
 		So(fn.ValidExposure(ZOME_EXPOSURE), ShouldBeTrue)
 	})
 }
+
+func TestValidationFailedErr(t *testing.T) {
+	Convey("it should build the default validation failed err", t, func() {
+		So(ValidationFailed(), ShouldEqual, ValidationFailedErr)
+	})
+	Convey("it should build the custom validation failed err", t, func() {
+		So(ValidationFailed("just because").Error(), ShouldEqual, ValidationFailedErrMsg+": just because")
+	})
+	Convey("it should test errors", t, func() {
+		So(IsValidationFailedErr(ValidationFailed("just because")), ShouldBeTrue)
+		So(IsValidationFailedErr(ValidationFailed()), ShouldBeTrue)
+		So(IsValidationFailedErr(ErrHashNotFound), ShouldBeFalse)
+	})
+
+}

--- a/service.go
+++ b/service.go
@@ -1516,7 +1516,7 @@ func TestingAppAppPackage() string {
         "Zome":   "zySampleZome",
         "FnName": "addEven",
         "Input":  "5",
-        "Err":    "Error calling 'commit': Validation Failed"
+        "Err":    "Error calling 'commit': Validation Failed: 5 is not even"
     },
     {
         "Zome":   "zySampleZome",
@@ -1571,13 +1571,13 @@ func TestingAppAppPackage() string {
 	"Zome":   "jsSampleZome",
 	"FnName": "addOdd",
 	"Input":  "2",
-	"Err":    {"errorMessage":"Validation Failed","function":"commit","name":"` + HolochainErrorPrefix + `","source":{"column":"28","functionName":"addOdd","line":"45"}}
+	"Err":    {"errorMessage":"Validation Failed: 2 is not odd","function":"commit","name":"` + HolochainErrorPrefix + `","source":{"column":"28","functionName":"addOdd","line":"45"}}
     },
     {
 	"Zome":   "jsSampleZome",
 	"FnName": "addOdd",
 	"Input":  "2",
-	"ErrMsg":  "Validation Failed"
+	"ErrMsg":  "Validation Failed: 2 is not odd"
     },
     {
 	"Zome":   "zySampleZome",
@@ -1715,7 +1715,7 @@ function validateCommit(entry_type,entry,header,pkg,sources) {
 }
 function validate(entry_type,entry,header,sources) {
   if (entry_type=="oddNumbers") {
-    return entry%2 != 0
+    return (entry%2 != 0) ? true : entry+" is not odd"
   }
   if (entry_type=="profile") {
     return true
@@ -1785,9 +1785,9 @@ function asyncPing(message,id) {
 (defn validateMod [entryType entry header replaces pkg sources] true)
 (defn validateDel [entryType hash pkg sources] true)
 (defn validate [entryType entry header sources]
-  (cond (== entryType "evenNumbers")  (cond (== (mod entry 2) 0) true false)
+  (cond (== entryType "evenNumbers")  (cond (== (mod entry 2) 0) true (concat (str entry) " is not even"))
         (== entryType "primes")  (isprime (hget entry %prime))
-        (== entryType "profile") true
+        (== entryType "profile") ""
         false)
 )
 (defn validateLink [linkEntryType baseHash links pkg sources] true)

--- a/ui/webserver_test.go
+++ b/ui/webserver_test.go
@@ -66,7 +66,7 @@ func TestWebServer(t *testing.T) {
 		b, err = ioutil.ReadAll(resp.Body)
 		So(err, ShouldBeNil)
 		So(resp.StatusCode, ShouldEqual, 400)
-		So(string(b), ShouldEqual, `{"errorMessage":"Validation Failed","function":"commit","name":"HolochainError","source":{"column":"28","functionName":"addOdd","line":"45"}}
+		So(string(b), ShouldEqual, `{"errorMessage":"Validation Failed: 2 is not odd","function":"commit","name":"HolochainError","source":{"column":"28","functionName":"addOdd","line":"45"}}
 `)
 	})
 

--- a/zygosome.go
+++ b/zygosome.go
@@ -278,13 +278,17 @@ func (z *ZygoRibosome) runValidate(fnName string, code string) (err error) {
 	case *zygo.SexpBool:
 		r := v.Val
 		if !r {
-			err = ValidationFailedErr
+			err = ValidationFailed()
+		}
+	case *zygo.SexpStr:
+		if v.S != "" {
+			err = ValidationFailed(v.S)
 		}
 	case *zygo.SexpSentinel:
-		err = fmt.Errorf("%s should return boolean, got nil", fnName)
+		err = fmt.Errorf("%s should return boolean or string, got nil", fnName)
 
 	default:
-		err = fmt.Errorf("%s should return boolean, got: %v", fnName, result)
+		err = fmt.Errorf("%s should return boolean or string, got: %v", fnName, result)
 	}
 	return
 }

--- a/zygosome_test.go
+++ b/zygosome_test.go
@@ -405,7 +405,7 @@ foo
 		a := NewCommitAction("oddNumbers", &GobEntry{C: "cow"})
 		a.header = &hdr
 		err = v.ValidateAction(a, &d, nil, nil)
-		So(err, ShouldEqual, ValidationFailedErr)
+		So(IsValidationFailedErr(err), ShouldBeTrue)
 
 		a = NewCommitAction("oddNumbers", &GobEntry{C: "fish"})
 		a.header = &hdr
@@ -419,7 +419,7 @@ foo
 		a := NewCommitAction("oddNumbers", &GobEntry{C: "\"cow\""})
 		a.header = &hdr
 		err = v.ValidateAction(a, &d, nil, nil)
-		So(err, ShouldEqual, ValidationFailedErr)
+		So(IsValidationFailedErr(err), ShouldBeTrue)
 
 		a = NewCommitAction("oddNumbers", &GobEntry{C: "\"fish\""})
 		a.header = &hdr
@@ -433,7 +433,7 @@ foo
 		a := NewCommitAction("evenNumbers", &GobEntry{C: `{"data":"cow"}`})
 		a.header = &hdr
 		err = v.ValidateAction(a, &d, nil, nil)
-		So(err, ShouldEqual, ValidationFailedErr)
+		So(IsValidationFailedErr(err), ShouldBeTrue)
 
 		a = NewCommitAction("evenNumbers", &GobEntry{C: `{"data":"fish"}`})
 		a.header = &hdr


### PR DESCRIPTION
you can still return booleans for back ward compatibility.  returning `""` is equivalent to returning `true`, i.e. valid.