### PR TITLE
fixes to hcdev and service.go re absolute paths, fixes #627

### DIFF
--- a/cmd/hcdev/hcdev.go
+++ b/cmd/hcdev/hcdev.go
@@ -88,7 +88,7 @@ func setupApp() (app *cli.App) {
 	app = cli.NewApp()
 	app.Name = "hcdev"
 	app.Usage = "holochain dev command line tool"
-	app.Version = fmt.Sprintf("0.0.3 (holochain %s)", holo.VersionStr)
+	app.Version = fmt.Sprintf("0.0.4 (holochain %s)", holo.VersionStr)
 
 	var service *holo.Service
 	var serverID, agentID, identity string
@@ -256,7 +256,12 @@ func setupApp() (app *cli.App) {
 				if name == "" {
 					name = args[0]
 				}
-				devPath = filepath.Join(devPath, name)
+				if filepath.IsAbs(name) {
+					devPath = name
+					name = filepath.Base(name)
+				} else {
+					devPath = filepath.Join(devPath, name)
+				}
 
 				info, err := os.Stat(devPath)
 				if err == nil && info.Mode().IsDir() {
@@ -360,6 +365,7 @@ func setupApp() (app *cli.App) {
 
 					var appPackage *holo.AppPackage
 					appPackage, err = service.SaveFromAppPackage(appPackageReader, devPath, name, agent, holo.BasicTemplateAppPackageFormat, encodingFormat, true)
+					fmt.Printf("ERR:%v", err)
 					if err != nil {
 						return cmd.MakeErrFromErr(c, err)
 					}

--- a/cmd/hcdev/hcdev_test.go
+++ b/cmd/hcdev/hcdev_test.go
@@ -106,6 +106,16 @@ func TestInit(t *testing.T) {
 		So(cmd.IsDir(tmpTestDir, holo.ChainDataDir), ShouldBeFalse)
 	})
 
+	Convey("'init /tmp/foo' should create default files in the absolute '/tmp/foo' directory", t, func() {
+		tmpFoo := filepath.Join("/tmp", "foo")
+		os.Args = []string{"hcdev", "init", tmpFoo}
+		err = app.Run(os.Args)
+		So(err, ShouldBeNil)
+		So(cmd.IsFile(filepath.Join(tmpFoo, "dna", "dna.json")), ShouldBeTrue)
+		So(cmd.IsDir(tmpTestDir, holo.ChainDataDir), ShouldBeFalse)
+		os.RemoveAll(tmpFoo)
+	})
+
 	Convey("'init bar --clone foo' should copy files from foo to bar", t, func() {
 		p := filepath.Join(tmpTestDir, "foo", "ui", "foo.js")
 		f, err := os.Create(p)

--- a/service.go
+++ b/service.go
@@ -706,8 +706,13 @@ func (s *Service) MakeTestingApp(root string, encodingFormat string, initDB bool
 	if DirExists(root) {
 		return nil, mkErr(root + " already exists")
 	}
-
 	appPackageReader := bytes.NewBuffer([]byte(TestingAppAppPackage()))
+
+	if filepath.IsAbs(root) {
+		origPath := s.Path
+		s.Path = filepath.Dir(root)
+		defer func() { s.Path = origPath }()
+	}
 
 	name := filepath.Base(root)
 	_, err = s.SaveFromAppPackage(appPackageReader, root, "test", agent, TestingAppDecodingFormat, encodingFormat, newUUID)
@@ -749,7 +754,6 @@ func (s *Service) MakeTestingApp(root string, encodingFormat string, initDB bool
 		if err = h.Config.Setup(); err != nil {
 			return
 		}
-
 	}
 	return
 }

--- a/service_test.go
+++ b/service_test.go
@@ -362,6 +362,14 @@ func TestMakeTestingApp(t *testing.T) {
 			So(err.Error(), ShouldEqual, "holochain: "+root+" already exists")
 		})
 	})
+
+	Convey("generating a dev holochain in an absolute directory initdb should work", t, func() {
+		root := filepath.Join("/tmp", "foo")
+		_, err := s.MakeTestingApp(root, "json", InitializeDB, CloneWithNewUUID, nil)
+		os.RemoveAll(root)
+		So(err, ShouldBeNil)
+	})
+
 }
 
 func TestSaveFromAppPackage(t *testing.T) {


### PR DESCRIPTION
in testing #622 I found that this:

`hcdev init /tmp/foo` failed

This is now fixed.