### PR TITLE
Create test chain for testing dump chain/dht, closes #632

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -720,16 +721,34 @@ func appendEntryHeaderAsJSON(buffer *bytes.Buffer, hdr *Header, hash *Hash) {
 
 func appendEntryContentAsJSON(buffer *bytes.Buffer, hdr *Header, g *GobEntry) {
 	buffer.WriteString("\"content\":")
+	buffer.WriteString(jsonEncode(g))
+}
 
+func jsonEncode(g *GobEntry) (encodedValue string) {
+	var err error
 	switch g.C.(type) {
-	case []uint8:
-		buffer.WriteString(fmt.Sprintf("%s", g.C))
-	default:
-		result, err := json.Marshal(g.C)
+	case []byte:
+		var decoded map[string]interface{}
+		content := fmt.Sprintf("%s", g.C)
+		buffer := bytes.NewBufferString(content)
+		err = Decode(buffer, "json", &decoded)
+
 		if err != nil {
-			fmt.Printf("Error: %s", err)
+			// DNA content may be TOML or YAML encoded, so escape it to make it JSON safe.
+			// (an improvement could be to convert from TOML/YAML to JSON)
+			encodedValue = strconv.Quote(content)
+		} else {
+			// DNA content is already in JSON so just use it.
+			encodedValue = content
+		}
+	default:
+		var result []byte
+		result, err = json.Marshal(g.C)
+		if err != nil {
+			encodedValue = strconv.Quote(err.Error())
 			return
 		}
-		buffer.WriteString(string(result))
+		encodedValue = string(result)
 	}
+	return
 }

--- a/cmd/hcdev/hcdev_test.go
+++ b/cmd/hcdev/hcdev_test.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strconv"
 	"testing"
 	"time"
 
@@ -20,6 +19,46 @@ func TestSetupApp(t *testing.T) {
 	app := setupApp()
 	Convey("it should create the cli App", t, func() {
 		So(app.Name, ShouldEqual, "hcdev")
+	})
+}
+
+func TestDump(t *testing.T) {
+	holo.InitializeHolochain()
+	d, s, h := holo.PrepareTestChain("test")
+	// port, _ := cmd.GetFreePort()
+	defer holo.CleanupTestChain(h, d)
+	app := setupApp()
+
+	Convey("dump --chain should show chain entries as a human readable string", t, func() {
+		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-no-nat-upnp", "-port=6001", "-execpath", s.Path, "-path", "test", "dump", "--chain"})
+
+		So(err, ShouldBeNil)
+		So(out, ShouldContainSubstring, "%dna:")
+		So(out, ShouldContainSubstring, "%agent:")
+	})
+
+	Convey("dump --dht should show chain entries as a human readable string", t, func() {
+		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-no-nat-upnp", "-port=6001", "-execpath", s.Path, "-path", "test", "dump", "--dht"})
+
+		So(err, ShouldBeNil)
+		So(out, ShouldContainSubstring, "DHT changes: 2")
+		So(out, ShouldContainSubstring, "DHT entries:")
+	})
+
+	Convey("dump --chain --json should show chain entries as JSON string", t, func() {
+		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-no-nat-upnp", "-port=6001", "-execpath", s.Path, "-path", "test", "dump", "--chain", "--json"})
+
+		So(err, ShouldBeNil)
+		So(out, ShouldContainSubstring, "{\n    \"%dna\": {")
+		So(out, ShouldContainSubstring, ",\n    \"%agent\": {")
+	})
+
+	Convey("dump --dht --json should show chain entries as JSON string", t, func() {
+		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-no-nat-upnp", "-port=6001", "-execpath", s.Path, "-path", "test", "dump", "--dht", "--json"})
+
+		So(err, ShouldBeNil)
+		So(out, ShouldContainSubstring, "\"dht_changes\": [")
+		So(out, ShouldContainSubstring, "\"dht_entries\": [")
 	})
 }
 
@@ -260,53 +299,6 @@ func TestIdenity(t *testing.T) {
 	})
 }
 
-func TestDump(t *testing.T) {
-	Convey("create an app dna", t, func() {
-		tmpTestDir, app := setupTestingApp("foo")
-		defer os.RemoveAll(tmpTestDir)
-
-		port, err := cmd.GetFreePort()
-		So(err, ShouldBeNil)
-
-		portArgument := strconv.Itoa(port)
-		_, err = cmd.RunAppWithStdoutCapture(app, []string{"hcdev", "-no-nat-upnp", "web", portArgument}, 1*time.Second)
-
-		So(err, ShouldBeNil)
-
-		Convey("dump --chain should show chain entries as a human readable string", func() {
-			out, err := cmd.RunAppWithStdoutCapture(app, []string{"hcdev", "-path", tmpTestDir + "/foo", "dump", "--chain"}, 1*time.Second)
-
-			So(err, ShouldBeNil)
-			So(out, ShouldContainSubstring, "%dna:")
-			So(out, ShouldContainSubstring, "%agent:")
-		})
-
-		Convey("dump --dht should show chain entries as a human readable string", func() {
-			out, err := cmd.RunAppWithStdoutCapture(app, []string{"hcdev", "-path", tmpTestDir + "/foo", "dump", "--dht"}, 1*time.Second)
-
-			So(err, ShouldBeNil)
-			So(out, ShouldContainSubstring, "DHT changes: 2")
-			So(out, ShouldContainSubstring, "DHT entries:")
-		})
-
-		Convey("dump --chain --json should show chain entries as JSON string", func() {
-			out, err := cmd.RunAppWithStdoutCapture(app, []string{"hcdev", "-path", tmpTestDir + "/foo", "dump", "--chain", "--json"}, 1*time.Second)
-
-			So(err, ShouldBeNil)
-			So(out, ShouldContainSubstring, "{\n    \"%dna\": {")
-			So(out, ShouldContainSubstring, ",\n    \"%agent\": {")
-		})
-
-		Convey("dump --dht --json should show chain entries as JSON string", func() {
-			out, err := cmd.RunAppWithStdoutCapture(app, []string{"hcdev", "-path", tmpTestDir + "/foo", "dump", "--dht", "--json"}, 1*time.Second)
-
-			So(err, ShouldBeNil)
-			So(out, ShouldContainSubstring, "\"dht_changes\": [")
-			So(out, ShouldContainSubstring, "\"dht_entries\": [")
-		})
-	})
-}
-
 func setupTestingApp(name string) (string, *cli.App) {
 	tmpTestDir, err := ioutil.TempDir("", "holochain.testing.hcdev")
 	if err != nil {
@@ -335,4 +327,8 @@ func setupTestingApp(name string) (string, *cli.App) {
 		panic(err)
 	}
 	return tmpTestDir, app
+}
+
+func runAppWithStdoutCapture(app *cli.App, args []string) (out string, err error) {
+	return cmd.RunAppWithStdoutCapture(app, args, time.Second*5)
 }


### PR DESCRIPTION
* Create test chain using `holo.PrepareTestChain` for testing dump
* Handle DNA content that is not JSON encoded when using --json flag (e.g. when DNA content is TOML or YAML)

An improvement could be to convert from TOML/YAML to JSON so that the dump looks nicer.