### PR TITLE
Initial implementation of dump chain to dot (GraphViz)

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -635,6 +636,73 @@ func (c *Chain) JSON() (string, error) {
 
 	buffer.WriteString("}")
 	return PrettyPrintJSON(buffer.Bytes())
+}
+
+// Dot converts a chain to a GraphViz 'dot' format dump of the headers and entries
+func (c *Chain) Dot() (dump string, err error) {
+	c.lk.RLock()
+	defer c.lk.RUnlock()
+	l := len(c.Headers)
+
+	var buffer bytes.Buffer
+
+	buffer.WriteString("digraph chain {\n")
+	buffer.WriteString("graph [splines=line];\n")
+	buffer.WriteString(`node [shape=record fontname="Arial",fontsize="10",style="rounded, filled",penwidth=2,fontcolor="#c5c5c5",color="#8d00ff",fillcolor="#181818"];` + "\n")
+	buffer.WriteString(`edge [penwidth=2, color="#8d00ff"];` + "\n")
+
+	for i := 0; i < l; i++ {
+		hdr := c.Headers[i]
+		hash := c.Hashes[i]
+		headerLabel := ""
+		contentLabel := ""
+		contentBody := ""
+
+		if i == 0 {
+			headerLabel = ": GENESIS"
+		}
+
+		// header
+		buffer.WriteString(fmt.Sprintf("header%d [label=<{HEADER %d%s|\n", i, i, headerLabel))
+		buffer.WriteString(fmt.Sprintf("{Type|%s}|\n", hdr.Type))
+		buffer.WriteString(fmt.Sprintf("{Hash|%s}|\n", hash))
+		buffer.WriteString(fmt.Sprintf("{Timestamp|%v}|\n", hdr.Time))
+		buffer.WriteString(fmt.Sprintf("{Next Header|%v}|\n", hdr.HeaderLink))
+		buffer.WriteString(fmt.Sprintf("{Next|%s: %v}|\n", hdr.Type, hdr.TypeLink))
+		buffer.WriteString(fmt.Sprintf("{Entry|%v}\n", hdr.EntryLink))
+		buffer.WriteString("}>];\n")
+
+		if i == 0 {
+			contentLabel = "HOLOCHAIN DNA"
+		} else if i == 1 {
+			contentLabel = "AGENT ID"
+		} else {
+			contentLabel = fmt.Sprintf("ENTRY %d", i)
+		}
+
+		if i == 0 {
+			contentBody = "See dna.json"
+		} else {
+			e := c.Entries[i]
+			contentBody = fmt.Sprintf("%s", e.(*GobEntry).C)
+			contentBody = strings.Replace(contentBody, `{"`, `\{"`, -1)
+			contentBody = strings.Replace(contentBody, `"}`, `"\}`, -1)
+			contentBody = strings.Replace(contentBody, `:[`, `:[<br/>`, -1)
+			contentBody = strings.Replace(contentBody, `]}`, `]\}`, -1)
+			contentBody = strings.Replace(contentBody, `,`, `,<br/>`, -1)
+		}
+
+		buffer.WriteString(fmt.Sprintf("content%d [label=<{%s|%s}>];\n", i, contentLabel, contentBody))
+
+		// arrows
+		buffer.WriteString(fmt.Sprintf("header%d->content%d;\n", i, i))
+		if i < l-1 {
+			buffer.WriteString(fmt.Sprintf("header%d->header%d;\n", i, i+1))
+		}
+	}
+
+	buffer.WriteString("}")
+	return buffer.String(), nil
 }
 
 // Length returns the number of entries in the chain

--- a/chain_test.go
+++ b/chain_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -473,6 +474,165 @@ func TestChain2JSON(t *testing.T) {
 		matched, err := regexp.MatchString(`{"%dna":{.*},"%agent":{.*},"entries":\[{"header":{"type":"handle",.*"},"content":"chain entry"}\]}`, json)
 		So(err, ShouldBeNil)
 		So(matched, ShouldBeTrue)
+	})
+}
+
+func TestChain2Dot(t *testing.T) {
+	hashSpec, key, now := chainTestSetup()
+	c := NewChain(hashSpec)
+
+	Convey("it should dump an empty 'dot' document for empty chain", t, func() {
+		dot, err := c.Dot()
+		So(err, ShouldBeNil)
+		matched, err := regexp.MatchString(`digraph chain {.*}`, strings.Replace(dot, "\n", "", -1))
+		So(err, ShouldBeNil)
+		So(matched, ShouldBeTrue)
+		So(dot, ShouldNotContainSubstring, "header")
+		So(dot, ShouldNotContainSubstring, "content")
+	})
+
+	e := GobEntry{C: "dna entry"}
+	c.AddEntry(now, DNAEntryType, &e, key)
+
+	Convey("after adding the dna, the dump should include the genesis entry in 'dot' format", t, func() {
+		dot, err := c.Dot()
+		So(err, ShouldBeNil)
+
+		hdr := c.Headers[0]
+		timestamp := fmt.Sprintf("%v", hdr.Time)
+		hdrType := fmt.Sprintf("%v", hdr.Type)
+		hdrEntry := fmt.Sprintf("%v", hdr.EntryLink)
+		nextHeader := fmt.Sprintf("%v", hdr.HeaderLink)
+		next := fmt.Sprintf("%s: %v", hdr.Type, hdr.TypeLink)
+		hash := fmt.Sprintf("%s", c.Hashes[0])
+
+		expectedDot := `header0 [label=<{HEADER 0: GENESIS|
+{Type|` + hdrType + `}|
+{Hash|` + hash + `}|
+{Timestamp|` + timestamp + `}|
+{Next Header|` + nextHeader + `}|
+{Next|` + next + `}|
+{Entry|` + hdrEntry + `}
+}>];
+content0 [label=<{HOLOCHAIN DNA|See dna.json}>];
+header0->content0;`
+
+		So(dot, ShouldContainSubstring, expectedDot)
+	})
+
+	e = GobEntry{C: `{"Identity":"lucy","Revocation":"","PublicKey":"XYZ"}`}
+	c.AddEntry(now, AgentEntryType, &e, key)
+
+	Convey("after adding the agent, the dump should include the agent entry in 'dot' format", t, func() {
+		dot, err := c.Dot()
+		So(err, ShouldBeNil)
+
+		hdr0 := c.Headers[0]
+		timestamp0 := fmt.Sprintf("%v", hdr0.Time)
+		hdrType0 := fmt.Sprintf("%v", hdr0.Type)
+		hdrEntry0 := fmt.Sprintf("%v", hdr0.EntryLink)
+		nextHeader0 := fmt.Sprintf("%v", hdr0.HeaderLink)
+		next0 := fmt.Sprintf("%s: %v", hdr0.Type, hdr0.TypeLink)
+		hash0 := fmt.Sprintf("%s", c.Hashes[0])
+
+		hdr1 := c.Headers[1]
+		timestamp1 := fmt.Sprintf("%v", hdr1.Time)
+		hdrType1 := fmt.Sprintf("%v", hdr1.Type)
+		hdrEntry1 := fmt.Sprintf("%v", hdr1.EntryLink)
+		nextHeader1 := fmt.Sprintf("%v", hdr1.HeaderLink)
+		next1 := fmt.Sprintf("%s: %v", hdr1.Type, hdr1.TypeLink)
+		hash1 := fmt.Sprintf("%s", c.Hashes[1])
+
+		expectedDot := `header0 [label=<{HEADER 0: GENESIS|
+{Type|` + hdrType0 + `}|
+{Hash|` + hash0 + `}|
+{Timestamp|` + timestamp0 + `}|
+{Next Header|` + nextHeader0 + `}|
+{Next|` + next0 + `}|
+{Entry|` + hdrEntry0 + `}
+}>];
+content0 [label=<{HOLOCHAIN DNA|See dna.json}>];
+header0->content0;
+header0->header1;
+header1 [label=<{HEADER 1|
+{Type|` + hdrType1 + `}|
+{Hash|` + hash1 + `}|
+{Timestamp|` + timestamp1 + `}|
+{Next Header|` + nextHeader1 + `}|
+{Next|` + next1 + `}|
+{Entry|` + hdrEntry1 + `}
+}>];
+content1 [label=<{AGENT ID|\{"Identity":"lucy",<br/>"Revocation":"",<br/>"PublicKey":"XYZ"\}}>];
+header1->content1;`
+
+		So(dot, ShouldContainSubstring, expectedDot)
+	})
+
+	e = GobEntry{C: `{"Links":[{"Base":"ABC","Link":"XYZ","Tag":"handle"}]}`}
+	c.AddEntry(now, "handle", &e, key)
+
+	Convey("after adding an entry, the dump should include the entry in 'dot' format", t, func() {
+		dot, err := c.Dot()
+		So(err, ShouldBeNil)
+
+		hdr0 := c.Headers[0]
+		timestamp0 := fmt.Sprintf("%v", hdr0.Time)
+		hdrType0 := fmt.Sprintf("%v", hdr0.Type)
+		hdrEntry0 := fmt.Sprintf("%v", hdr0.EntryLink)
+		nextHeader0 := fmt.Sprintf("%v", hdr0.HeaderLink)
+		next0 := fmt.Sprintf("%s: %v", hdr0.Type, hdr0.TypeLink)
+		hash0 := fmt.Sprintf("%s", c.Hashes[0])
+
+		hdr1 := c.Headers[1]
+		timestamp1 := fmt.Sprintf("%v", hdr1.Time)
+		hdrType1 := fmt.Sprintf("%v", hdr1.Type)
+		hdrEntry1 := fmt.Sprintf("%v", hdr1.EntryLink)
+		nextHeader1 := fmt.Sprintf("%v", hdr1.HeaderLink)
+		next1 := fmt.Sprintf("%s: %v", hdr1.Type, hdr1.TypeLink)
+		hash1 := fmt.Sprintf("%s", c.Hashes[1])
+
+		hdr2 := c.Headers[2]
+		timestamp2 := fmt.Sprintf("%v", hdr2.Time)
+		hdrType2 := fmt.Sprintf("%v", hdr2.Type)
+		hdrEntry2 := fmt.Sprintf("%v", hdr2.EntryLink)
+		nextHeader2 := fmt.Sprintf("%v", hdr2.HeaderLink)
+		next2 := fmt.Sprintf("%s: %v", hdr2.Type, hdr2.TypeLink)
+		hash2 := fmt.Sprintf("%s", c.Hashes[2])
+
+		expectedDot := `header0 [label=<{HEADER 0: GENESIS|
+{Type|` + hdrType0 + `}|
+{Hash|` + hash0 + `}|
+{Timestamp|` + timestamp0 + `}|
+{Next Header|` + nextHeader0 + `}|
+{Next|` + next0 + `}|
+{Entry|` + hdrEntry0 + `}
+}>];
+content0 [label=<{HOLOCHAIN DNA|See dna.json}>];
+header0->content0;
+header0->header1;
+header1 [label=<{HEADER 1|
+{Type|` + hdrType1 + `}|
+{Hash|` + hash1 + `}|
+{Timestamp|` + timestamp1 + `}|
+{Next Header|` + nextHeader1 + `}|
+{Next|` + next1 + `}|
+{Entry|` + hdrEntry1 + `}
+}>];
+content1 [label=<{AGENT ID|\{"Identity":"lucy",<br/>"Revocation":"",<br/>"PublicKey":"XYZ"\}}>];
+header1->content1;
+header1->header2;
+header2 [label=<{HEADER 2|
+{Type|` + hdrType2 + `}|
+{Hash|` + hash2 + `}|
+{Timestamp|` + timestamp2 + `}|
+{Next Header|` + nextHeader2 + `}|
+{Next|` + next2 + `}|
+{Entry|` + hdrEntry2 + `}
+}>];
+content2 [label=<{ENTRY 2|\{"Links":[<br/>\{"Base":"ABC",<br/>"Link":"XYZ",<br/>"Tag":"handle"\}]\}}>];
+header2->content2;`
+
+		So(dot, ShouldContainSubstring, expectedDot)
 	})
 }
 

--- a/cmd/hcdev/hcdev.go
+++ b/cmd/hcdev/hcdev.go
@@ -166,7 +166,7 @@ func setupApp() (app *cli.App) {
 	}
 
 	var dumpChain, dumpDHT, initTest, fromDevelop, benchmarks, json bool
-	var clonePath, appPackagePath, cloneExample, outputDir, fromBranch string
+	var clonePath, appPackagePath, cloneExample, outputDir, fromBranch, dumpFormat string
 
 	app.Commands = []cli.Command{
 		{
@@ -755,6 +755,12 @@ func setupApp() (app *cli.App) {
 					Name:        "scenario",
 					Destination: &dumpScenario,
 				},
+				cli.StringFlag{
+					Name:        "format",
+					Destination: &dumpFormat,
+					Usage:       "Dump format (string, json, dot)",
+					Value:       "string",
+				},
 			},
 			Action: func(c *cli.Context) error {
 
@@ -797,6 +803,19 @@ func setupApp() (app *cli.App) {
 					if json {
 						dump, _ := h.Chain().JSON()
 						fmt.Println(dump)
+					} else if dumpFormat != "" {
+						switch dumpFormat {
+						case "string":
+							fmt.Printf("Chain for: %s\n%v", dnaHash, h.Chain())
+						case "dot":
+							dump, _ := h.Chain().Dot()
+							fmt.Println(dump)
+						case "json":
+							dump, _ := h.Chain().JSON()
+							fmt.Println(dump)
+						default:
+							return cmd.MakeErr(c, "format must be one of dot,json,string")
+						}
 					} else {
 						fmt.Printf("Chain for: %s\n%v", dnaHash, h.Chain())
 					}

--- a/cmd/hcdev/hcdev_test.go
+++ b/cmd/hcdev/hcdev_test.go
@@ -26,11 +26,10 @@ func TestSetupApp(t *testing.T) {
 func TestDump(t *testing.T) {
 	holo.InitializeHolochain()
 	d, s, h := holo.PrepareTestChain("test")
-	// port, _ := cmd.GetFreePort()
 	defer holo.CleanupTestChain(h, d)
 	app := setupApp()
 
-	Convey("dump --chain should show chain entries as a human readable string", t, func() {
+	Convey("'dump --chain' should show chain entries as a human readable string", t, func() {
 		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-no-nat-upnp", "-port=6001", "-execpath", s.Path, "-path", "test", "dump", "--chain"})
 
 		So(err, ShouldBeNil)
@@ -38,7 +37,7 @@ func TestDump(t *testing.T) {
 		So(out, ShouldContainSubstring, "%agent:")
 	})
 
-	Convey("dump --dht should show chain entries as a human readable string", t, func() {
+	Convey("'dump --dht' should show chain entries as a human readable string", t, func() {
 		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-no-nat-upnp", "-port=6001", "-execpath", s.Path, "-path", "test", "dump", "--dht"})
 
 		So(err, ShouldBeNil)
@@ -46,7 +45,7 @@ func TestDump(t *testing.T) {
 		So(out, ShouldContainSubstring, "DHT entries:")
 	})
 
-	Convey("dump --chain --json should show chain entries as JSON string", t, func() {
+	Convey("'dump --chain --json' should show chain entries as JSON string", t, func() {
 		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-no-nat-upnp", "-port=6001", "-execpath", s.Path, "-path", "test", "dump", "--chain", "--json"})
 
 		So(err, ShouldBeNil)
@@ -54,12 +53,27 @@ func TestDump(t *testing.T) {
 		So(out, ShouldContainSubstring, ",\n    \"%agent\": {")
 	})
 
-	Convey("dump --dht --json should show chain entries as JSON string", t, func() {
+	Convey("'dump --dht --json' should show chain entries as JSON string", t, func() {
 		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-no-nat-upnp", "-port=6001", "-execpath", s.Path, "-path", "test", "dump", "--dht", "--json"})
 
 		So(err, ShouldBeNil)
 		So(out, ShouldContainSubstring, "\"dht_changes\": [")
 		So(out, ShouldContainSubstring, "\"dht_entries\": [")
+	})
+
+	Convey("'dump --chain --format string' should show chain entries as a human readable string", t, func() {
+		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-no-nat-upnp", "-port=6001", "-execpath", s.Path, "-path", "test", "dump", "--chain", "--format", "string"})
+
+		So(err, ShouldBeNil)
+		So(out, ShouldContainSubstring, "%dna:")
+		So(out, ShouldContainSubstring, "%agent:")
+	})
+
+	Convey("'dump --chain --format dot' should show chain entries as GraphViz DOT format", t, func() {
+		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-no-nat-upnp", "-port=6001", "-execpath", s.Path, "-path", "test", "dump", "--chain", "--format", "dot"})
+
+		So(err, ShouldBeNil)
+		So(out, ShouldContainSubstring, "digraph chain {")
 	})
 }
 


### PR DESCRIPTION
Dumps the chain to DOT format (to stdout).

* DHT dump to dot not implemented in this PR (coming soon)
* adds new `--format` argument (e.g. --format dot) that accepts previous formats as well.
* existing `--json` flag still supported for backwards compatibility (can be deprecated later if desired)

Example usage:

Dump chain:

```
hcdev -execpath ~/.holochaindev -path clutter dump --chain --format dot > clutter.dot
```

Then view in a graphical DOT viewer:

```
xdot clutter.dot
```