### PR TITLE
update defaults for upnp and mdns, closes #664

### DIFF
--- a/apptest/apptest_test.go
+++ b/apptest/apptest_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	// disable UPNP for tests
+	os.Setenv("HOLOCHAINCONFIG_ENABLENATUPNP", "false")
 	InitializeHolochain()
 	os.Exit(m.Run())
 }

--- a/bin/test.examples
+++ b/bin/test.examples
@@ -33,7 +33,7 @@ for app in "${EXAMPLES[@]}"
 do
     hcdev init -fromBranch=$BRANCH -cloneExample $app $app
     cd $app
-    hcdev -no-nat-upnp -mdns=true test
+    hcdev test
     r=$?
     RESULTS[$i]="$r"
     i=$i+1

--- a/cmd/hcadmin/hcadmin_test.go
+++ b/cmd/hcadmin/hcadmin_test.go
@@ -14,6 +14,13 @@ import (
 	"github.com/urfave/cli"
 )
 
+func TestMain(m *testing.M) {
+	// disable UPNP for tests
+	os.Setenv("HOLOCHAINCONFIG_ENABLENATUPNP", "false")
+	holo.InitializeHolochain()
+	os.Exit(m.Run())
+}
+
 func TestSetupApp(t *testing.T) {
 	app := setupApp()
 	Convey("it should create the cli App", t, func() {

--- a/cmd/hcd/hcd.go
+++ b/cmd/hcd/hcd.go
@@ -20,7 +20,6 @@ const (
 
 var debug bool
 var verbose bool
-var nonatupnp bool
 
 func setupApp() (app *cli.App) {
 	app = cli.NewApp()

--- a/cmd/hcd/hcd_test.go
+++ b/cmd/hcd/hcd_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	// disable UPNP for tests
+	os.Setenv("HOLOCHAINCONFIG_ENABLENATUPNP", "false")
 	holo.InitializeHolochain()
 	os.Exit(m.Run())
 }

--- a/cmd/hcdev/hcdev.go
+++ b/cmd/hcdev/hcdev.go
@@ -130,12 +130,12 @@ func setupApp() (app *cli.App) {
 		},
 		cli.BoolTFlag{
 			Name:        "mdns",
-			Usage:       "whether to use mdns for local peer discovery (default = true)",
+			Usage:       "whether to use mdns for local peer discovery (default: true)",
 			Destination: &mdns,
 		},
 		cli.BoolFlag{
 			Name:        "upnp",
-			Usage:       "whether to use UPnP for creating a NAT port mapping (default true)",
+			Usage:       "whether to use UPnP for creating a NAT port mapping (default: false)",
 			Destination: &upnp,
 		},
 		cli.StringFlag{

--- a/cmd/hcdev/hcdev.go
+++ b/cmd/hcdev/hcdev.go
@@ -42,8 +42,8 @@ var scenarioConfig *holo.TestConfig
 
 // flags for holochain config generation
 var port, logPrefix, bootstrapServer string
-var mdns bool
-var nonatupnp bool
+var mdns bool = true
+var upnp bool
 
 // meta flags for program flow control
 var syncPausePath string
@@ -70,7 +70,7 @@ func appCheck(devPath string) error {
 }
 func setupApp() (app *cli.App) {
 
-	// clear these values so we can call this multiple time for testing
+	// set default values so we can call this multiple time for testing
 	debug = false
 	appInitialized = false
 	rootPath = ""
@@ -128,15 +128,15 @@ func setupApp() (app *cli.App) {
 			Usage:       "port on which to run the test/scenario instance",
 			Destination: &port,
 		},
-		cli.BoolFlag{
+		cli.BoolTFlag{
 			Name:        "mdns",
-			Usage:       "whether to use mdns for local peer discovery",
+			Usage:       "whether to use mdns for local peer discovery (default = true)",
 			Destination: &mdns,
 		},
 		cli.BoolFlag{
-			Name:        "no-nat-upnp",
-			Usage:       "whether to stop hcdev from creating a port mapping through NAT via UPnP",
-			Destination: &nonatupnp,
+			Name:        "upnp",
+			Usage:       "whether to use UPnP for creating a NAT port mapping (default true)",
+			Destination: &upnp,
 		},
 		cli.StringFlag{
 			Name:        "logPrefix",
@@ -587,20 +587,19 @@ func setupApp() (app *cli.App) {
 							logPrefix = "%{time}" + logPrefix
 						}*/
 
-						var nonat string
+						var upnpnat string
 						if bootstrapServer == "_" {
-							nonat = "true"
+							upnpnat = "false"
 						} else {
-							nonat = "false"
+							upnpnat = "true"
 						}
-
 						testCommand := exec.Command(
 							"hcdev",
 							"-path="+devPath,
 							"-execpath="+filepath.Join(rootExecDir, roleName),
 							"-port="+strconv.Itoa(freePort),
 							fmt.Sprintf("-mdns=%v", mdns),
-							"-no-nat-upnp="+nonat,
+							"-upnp="+upnpnat,
 							"-logPrefix="+logPrefix,
 							"-serverID="+serverID,
 							"-agentID="+agentID,
@@ -835,7 +834,6 @@ func setupApp() (app *cli.App) {
 	}
 
 	app.Before = func(c *cli.Context) error {
-
 		lastRunContext = c
 
 		var err error
@@ -846,14 +844,14 @@ func setupApp() (app *cli.App) {
 				return err
 			}
 		}
-		if mdns != false {
+		if mdns {
 			err = os.Setenv("HOLOCHAINCONFIG_ENABLEMDNS", "true")
 			if err != nil {
 				return err
 			}
 		}
-		if nonatupnp == false {
-			err = os.Setenv("HOLOCHAINCONFIG_ENABLENATUPNP", "true")
+		if upnp != true {
+			err = os.Setenv("HOLOCHAINCONFIG_ENABLENATUPNP", "false")
 			if err != nil {
 				return err
 			}

--- a/cmd/hcdev/hcdev_test.go
+++ b/cmd/hcdev/hcdev_test.go
@@ -16,6 +16,13 @@ import (
 	"github.com/urfave/cli"
 )
 
+func TestMain(m *testing.M) {
+	// disable UPNP for tests
+	os.Setenv("HOLOCHAINCONFIG_ENABLENATUPNP", "false")
+	holo.InitializeHolochain()
+	os.Exit(m.Run())
+}
+
 func TestSetupApp(t *testing.T) {
 	app := setupApp()
 	Convey("it should create the cli App", t, func() {
@@ -24,13 +31,12 @@ func TestSetupApp(t *testing.T) {
 }
 
 func TestDump(t *testing.T) {
-	holo.InitializeHolochain()
 	d, s, h := holo.PrepareTestChain("test")
 	defer holo.CleanupTestChain(h, d)
 	app := setupApp()
 
 	Convey("'dump --chain' should show chain entries as a human readable string", t, func() {
-		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-no-nat-upnp", "-port=6001", "-execpath", s.Path, "-path", "test", "dump", "--chain"})
+		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-port=6001", "-execpath", s.Path, "-path", "test", "dump", "--chain"})
 
 		So(err, ShouldBeNil)
 		So(out, ShouldContainSubstring, "%dna:")
@@ -38,7 +44,7 @@ func TestDump(t *testing.T) {
 	})
 
 	Convey("'dump --dht' should show chain entries as a human readable string", t, func() {
-		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-no-nat-upnp", "-port=6001", "-execpath", s.Path, "-path", "test", "dump", "--dht"})
+		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-port=6001", "-execpath", s.Path, "-path", "test", "dump", "--dht"})
 
 		So(err, ShouldBeNil)
 		So(out, ShouldContainSubstring, "DHT changes: 2")
@@ -46,7 +52,7 @@ func TestDump(t *testing.T) {
 	})
 
 	Convey("'dump --chain --json' should show chain entries as JSON string", t, func() {
-		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-no-nat-upnp", "-port=6001", "-execpath", s.Path, "-path", "test", "dump", "--chain", "--json"})
+		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-port=6001", "-execpath", s.Path, "-path", "test", "dump", "--chain", "--json"})
 
 		So(err, ShouldBeNil)
 		So(out, ShouldContainSubstring, "{\n    \"%dna\": {")
@@ -54,7 +60,7 @@ func TestDump(t *testing.T) {
 	})
 
 	Convey("'dump --dht --json' should show chain entries as JSON string", t, func() {
-		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-no-nat-upnp", "-port=6001", "-execpath", s.Path, "-path", "test", "dump", "--dht", "--json"})
+		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-port=6001", "-execpath", s.Path, "-path", "test", "dump", "--dht", "--json"})
 
 		So(err, ShouldBeNil)
 		So(out, ShouldContainSubstring, "\"dht_changes\": [")
@@ -62,7 +68,7 @@ func TestDump(t *testing.T) {
 	})
 
 	Convey("'dump --chain --format string' should show chain entries as a human readable string", t, func() {
-		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-no-nat-upnp", "-port=6001", "-execpath", s.Path, "-path", "test", "dump", "--chain", "--format", "string"})
+		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-port=6001", "-execpath", s.Path, "-path", "test", "dump", "--chain", "--format", "string"})
 
 		So(err, ShouldBeNil)
 		So(out, ShouldContainSubstring, "%dna:")
@@ -70,11 +76,12 @@ func TestDump(t *testing.T) {
 	})
 
 	Convey("'dump --chain --format dot' should show chain entries as GraphViz DOT format", t, func() {
-		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-no-nat-upnp", "-port=6001", "-execpath", s.Path, "-path", "test", "dump", "--chain", "--format", "dot"})
+		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-port=6001", "-execpath", s.Path, "-path", "test", "dump", "--chain", "--format", "dot"})
 
 		So(err, ShouldBeNil)
 		So(out, ShouldContainSubstring, "digraph chain {")
 	})
+	os.Unsetenv("HOLOCHAINCONFIG_ENABLENATUPNP")
 }
 
 func TestGoScenario_cliCommand(t *testing.T) {
@@ -280,7 +287,7 @@ func TestWeb(t *testing.T) {
 	os.Unsetenv("HCLOG_DEBUG_ENABLE")
 
 	Convey("'web' should run a webserver", t, func() {
-		out, err := cmd.RunAppWithStdoutCapture(app, []string{"hcdev", "-no-nat-upnp", "web"}, 5*time.Second)
+		out, err := cmd.RunAppWithStdoutCapture(app, []string{"hcdev", "-upnp=false", "web"}, 5*time.Second)
 		So(err, ShouldBeNil)
 		So(out, ShouldContainSubstring, "on port:4141")
 		So(out, ShouldContainSubstring, "Serving holochain with DNA hash:")
@@ -291,7 +298,7 @@ func TestWeb(t *testing.T) {
 	app = setupApp()
 
 	Convey("'web -debug' should run a webserver and include holochain debug info", t, func() {
-		out, err := cmd.RunAppWithStdoutCapture(app, []string{"hcdev", "-debug", "-no-nat-upnp", "web", "4142"}, 5*time.Second)
+		out, err := cmd.RunAppWithStdoutCapture(app, []string{"hcdev", "-debug", "-upnp=false", "web", "4142"}, 5*time.Second)
 		So(err, ShouldBeNil)
 		So(out, ShouldContainSubstring, "running zyZome genesis")
 		So(out, ShouldContainSubstring, "NewEntry of %dna added as: Qm")
@@ -343,13 +350,47 @@ func TestBridging(t *testing.T) {
 	}
 
 	Convey("bridgeSpecsFile path should setup bridging", t, func() {
-		out, err := cmd.RunAppWithStdoutCapture(app, []string{"hcdev", "-bridgeSpecs", filepath.Join(tmpTestDir, "specs.json"), "-no-nat-upnp", "web"}, 5*time.Second)
+		out, err := cmd.RunAppWithStdoutCapture(app, []string{"hcdev", "-bridgeSpecs", filepath.Join(tmpTestDir, "specs.json"), "-upnp=false", "web"}, 5*time.Second)
 		So(err, ShouldBeNil)
 		//So(out, ShouldContainSubstring, fmt.Sprintf("bridging to %s using zome: jsSampleZome", bridgeSourceDir))
 		So(out, ShouldContainSubstring, fmt.Sprintf("Copying bridge chain bar to:"))
 		So(out, ShouldContainSubstring, fmt.Sprintf("bridge genesis to-- other side is:")) // getting the DNA is a pain so skip it.
 		So(out, ShouldContainSubstring, fmt.Sprintf("bridging data:some data 314"))
 	})
+}
+
+func TestConfigFlagsDefault(t *testing.T) {
+	os.Setenv("HC_TESTING", "true")
+	tmpTestDir, err := ioutil.TempDir("", "holochain.testing.hcdev")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(tmpTestDir)
+
+	runDir := filepath.Join(tmpTestDir, holo.DefaultDirectoryName+"dev")
+
+	os.Setenv("HOLOPATHDEV", runDir)
+
+	err = os.Chdir(tmpTestDir)
+	if err != nil {
+		panic(err)
+	}
+
+	app := setupApp()
+	_, err = runAppWithStdoutCapture(app, []string{"hcdev", "init", "foo"})
+
+	Convey("defaults are mdns on upnp off", t, func() {
+		app := setupApp()
+		runAppWithStdoutCapture(app, []string{"hcdev", "test"})
+		var config holo.Config
+		err = holo.DecodeFile(&config, filepath.Join(runDir, "foo", holo.ConfigFileName+".json"))
+		So(err, ShouldBeNil)
+		So(config.EnableMDNS, ShouldBeTrue)
+		So(config.EnableNATUPnP, ShouldBeFalse)
+	})
+
+	os.Unsetenv("HOLOPATHDEV")
+	os.Unsetenv("HC_TESTING")
 }
 
 func setupTestingApp(names ...string) (string, *cli.App) {

--- a/holochain_test.go
+++ b/holochain_test.go
@@ -16,6 +16,8 @@ import (
 
 func TestMain(m *testing.M) {
 	os.Setenv("_HCTEST", "1")
+	// disable UPNP for tests
+	os.Setenv("HOLOCHAINCONFIG_ENABLENATUPNP", "false")
 	InitializeHolochain()
 	os.Exit(m.Run())
 }
@@ -156,7 +158,7 @@ func TestDebuggingSetup(t *testing.T) {
 		log.Enabled = true
 
 		h.Debug("test")
-		So(string(buf.Bytes()), ShouldEqual, "HC: holochain_test.go.158: test\n")
+		So(string(buf.Bytes()), ShouldEqual, "HC: holochain_test.go.160: test\n")
 
 		// restore state of debug log
 		log.w = os.Stdout

--- a/service.go
+++ b/service.go
@@ -185,7 +185,7 @@ func Init(root string, identity AgentIdentity, seed io.Reader) (service *Service
 			DefaultPeerModeAuthor:  true,
 			DefaultBootstrapServer: DefaultBootstrapServer,
 			DefaultEnableMDNS:      false,
-			DefaultEnableNATUPnP:   false,
+			DefaultEnableNATUPnP:   true,
 		},
 		Path: root,
 	}
@@ -202,7 +202,7 @@ func Init(root string, identity AgentIdentity, seed io.Reader) (service *Service
 
 	if os.Getenv(DefaultEnableNATUPnPEnvVar) != "" && os.Getenv(DefaultEnableNATUPnPEnvVar) != "false" {
 		s.Settings.DefaultEnableNATUPnP = true
-		Infof("Using %s--configuring default MDNS use as: %v.\n", DefaultEnableNATUPnPEnvVar, s.Settings.DefaultEnableNATUPnP)
+		Infof("Using %s--configuring default UPnP use as: %v.\n", DefaultEnableNATUPnPEnvVar, s.Settings.DefaultEnableNATUPnP)
 	}
 
 	err = writeToml(root, SysFileName, s.Settings, false)

--- a/service_test.go
+++ b/service_test.go
@@ -27,7 +27,7 @@ func TestInit(t *testing.T) {
 
 		Convey("it should return a service with default values", func() {
 			So(s.DefaultAgent.Identity(), ShouldEqual, AgentIdentity(agent))
-			So(fmt.Sprintf("%v", s.Settings), ShouldEqual, "{true true bootstrap.holochain.net:10000 false false}")
+			So(fmt.Sprintf("%v", s.Settings), ShouldEqual, "{true true bootstrap.holochain.net:10000 false true}")
 		})
 
 		p := filepath.Join(d, DefaultDirectoryName)

--- a/ui/webserver_test.go
+++ b/ui/webserver_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	// disable UPNP for tests
+	os.Setenv("HOLOCHAINCONFIG_ENABLENATUPNP", "false")
 	InitializeHolochain()
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
for hcdev mode mdns defaults to true and upnp to false
for hcd the opposite

N.B. changed flag in `hcdev` from "-no-nat-upnp" -> "-upnp"