### PR TITLE
added a smoke test for docker that should fail tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ services:
 script:
 - make hcdev
 - TEST_FLAGS='-v -coverprofile=$(pkg_path)/coverage.txt -covermode=atomic' make -e test
+- docker build -t smoke-test docker && docker run smoke-test
 cache:
   directories:
   - $GOPATH/src/gx

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,4 +19,4 @@ COPY --from=build /go/bin/hccore /usr/local/bin/hccore
 COPY --from=build /go/bin/hcd /usr/local/bin/hcd
 COPY --from=build /go/bin/hcdev /usr/local/bin/hcdev
 
-CMD ["/bin/bash"]
+CMD ["/bin/bash/broken"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,4 +19,4 @@ COPY --from=build /go/bin/hccore /usr/local/bin/hccore
 COPY --from=build /go/bin/hcd /usr/local/bin/hcd
 COPY --from=build /go/bin/hcdev /usr/local/bin/hcdev
 
-CMD ["/bin/bash/broken"]
+CMD ["/bin/bash"]


### PR DESCRIPTION
fixes #672 

Example failing build: https://travis-ci.org/holochain/holochain-proto/builds/372653738?utm_source=github_status&utm_medium=notification

Example passing build: https://travis-ci.org/holochain/holochain-proto/builds/372656892?utm_source=github_status&utm_medium=notification