### PR TITLE
#692: Adds --format <string|json|dot> flag to hcadmin chain dump command

### DIFF
--- a/cmd/hcadmin/hcadmin.go
+++ b/cmd/hcadmin/hcadmin.go
@@ -28,7 +28,7 @@ func setupApp() (app *cli.App) {
 	var dumpChain, dumpDHT, json bool
 	var root string
 	var service *holo.Service
-	var bridgeCalleeAppData, bridgeCallerAppData string
+	var bridgeCalleeAppData, bridgeCallerAppData, dumpFormat string
 	var start int
 
 	app.Flags = []cli.Flag{
@@ -97,6 +97,12 @@ func setupApp() (app *cli.App) {
 					Destination: &start,
 					Usage:       "starting index for dump (zero based)",
 				},
+				cli.StringFlag{
+					Name:		 "format",
+					Destination: &dumpFormat,
+					Usage:		 "Dump format (string, json, dot)",
+					Value:	     "string",
+				},
 			},
 			Action: func(c *cli.Context) error {
 				h, err := cmd.GetHolochain(c.Args().First(), service, "dump")
@@ -112,6 +118,19 @@ func setupApp() (app *cli.App) {
 					if json {
 						dump, _ := h.Chain().JSON(start)
 						fmt.Println(dump)
+					} else if  dumpFormat != "" {
+						switch dumpFormat {
+						case "string":
+								fmt.Printf("Chain for: %s\n%v", dnaHash, h.Chain().Dump(start))
+						case "dot":
+								dump, _ := h.Chain().Dot(start)
+							 	fmt.Println(dump)
+						case "json":
+								dump, _ := h.Chain().JSON(start)
+								fmt.Println(dump)
+						default:
+								return cmd.MakeErr(c, "format must be one of dot, json, string")
+						}
 					} else {
 						fmt.Printf("Chain for: %s\n%v", dnaHash, h.Chain().Dump(start))
 					}

--- a/cmd/hcadmin/hcadmin.go
+++ b/cmd/hcadmin/hcadmin.go
@@ -98,10 +98,10 @@ func setupApp() (app *cli.App) {
 					Usage:       "starting index for dump (zero based)",
 				},
 				cli.StringFlag{
-					Name:		 "format",
+					Name:        "format",
 					Destination: &dumpFormat,
-					Usage:		 "Dump format (string, json, dot)",
-					Value:	     "string",
+					Usage:       "Dump format (string, json, dot)",
+					Value:       "string",
 				},
 			},
 			Action: func(c *cli.Context) error {
@@ -118,18 +118,18 @@ func setupApp() (app *cli.App) {
 					if json {
 						dump, _ := h.Chain().JSON(start)
 						fmt.Println(dump)
-					} else if  dumpFormat != "" {
+					} else if dumpFormat != "" {
 						switch dumpFormat {
 						case "string":
-								fmt.Printf("Chain for: %s\n%v", dnaHash, h.Chain().Dump(start))
+							fmt.Printf("Chain for: %s\n%v", dnaHash, h.Chain().Dump(start))
 						case "dot":
-								dump, _ := h.Chain().Dot(start)
-							 	fmt.Println(dump)
+							dump, _ := h.Chain().Dot(start)
+							fmt.Println(dump)
 						case "json":
-								dump, _ := h.Chain().JSON(start)
-								fmt.Println(dump)
+							dump, _ := h.Chain().JSON(start)
+							fmt.Println(dump)
 						default:
-								return cmd.MakeErr(c, "format must be one of dot, json, string")
+							return cmd.MakeErr(c, "format must be one of dot, json, string")
 						}
 					} else {
 						fmt.Printf("Chain for: %s\n%v", dnaHash, h.Chain().Dump(start))


### PR DESCRIPTION
I tested this by running each of the three options with hcdev, then each option using hcadmin, then diff-ing the output.  Diff found several differences between the two outputs, should they be identical or does this make sense?  I've attached output and diff files.

[dot_diff.txt](https://github.com/holochain/holochain-proto/files/1976900/dot_diff.txt)
[hcadmin_dot.txt](https://github.com/holochain/holochain-proto/files/1976901/hcadmin_dot.txt)
[hcadmin_json.txt](https://github.com/holochain/holochain-proto/files/1976902/hcadmin_json.txt)
[hcadmin_string.txt](https://github.com/holochain/holochain-proto/files/1976903/hcadmin_string.txt)
[hcdev_dot.txt](https://github.com/holochain/holochain-proto/files/1976904/hcdev_dot.txt)
[hcdev_json.txt](https://github.com/holochain/holochain-proto/files/1976905/hcdev_json.txt)
[hcdev_string.txt](https://github.com/holochain/holochain-proto/files/1976906/hcdev_string.txt)
[json_diff.txt](https://github.com/holochain/holochain-proto/files/1976907/json_diff.txt)
[string_diff.txt](https://github.com/holochain/holochain-proto/files/1976908/string_diff.txt)
