### PR TITLE
add cors headers to ui/webserver fn responses

### DIFF
--- a/ui/webserver.go
+++ b/ui/webserver.go
@@ -41,6 +41,7 @@ func NewWebServer(h *holo.Holochain, port string) *WebServer {
 func AddCors(w http.ResponseWriter) {
 	headers := w.Header()
 	headers.Set("Access-Control-Allow-Origin", "*")
+	headers.Set("Access-Control-Allow-Headers", "Content-Type")
 }
 
 //Start starts up a web server and returns a channel which will shutdown
@@ -111,6 +112,9 @@ func (ws *WebServer) Start() {
 		ws.log.Logf("REQUEST:%v", r)
 
 		AddCors(w)
+		if r.Method == "OPTIONS" {
+			return
+		}
 
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
@@ -197,6 +201,11 @@ func (ws *WebServer) Start() {
 				http.Error(w, err.Error(), errCode)
 			}
 		}()
+
+		AddCors(w)
+		if r.Method == "OPTIONS" {
+			return
+		}
 
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {

--- a/ui/webserver.go
+++ b/ui/webserver.go
@@ -37,6 +37,12 @@ func NewWebServer(h *holo.Holochain, port string) *WebServer {
 	return &w
 }
 
+// Helper for managing CORS responses
+func AddCors(w http.ResponseWriter) {
+	headers := w.Header()
+	headers.Set("Access-Control-Allow-Origin", "*")
+}
+
 //Start starts up a web server and returns a channel which will shutdown
 func (ws *WebServer) Start() {
 
@@ -103,6 +109,8 @@ func (ws *WebServer) Start() {
 		}()
 
 		ws.log.Logf("REQUEST:%v", r)
+
+		AddCors(w)
 
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {

--- a/ui/webserver_test.go
+++ b/ui/webserver_test.go
@@ -59,6 +59,15 @@ func TestWebServer(t *testing.T) {
 		So(string(b), ShouldEqual, "en")
 	})
 
+	Convey("it should return CORS headers when calling functions", t, func() {
+		body := bytes.NewBuffer([]byte("language"))
+		resp, err := http.Post("http://0.0.0.0:31415/fn/jsSampleZome/getProperty", "", body)
+		So(err, ShouldBeNil)
+		defer resp.Body.Close()
+		_, corsPresent := resp.Header["Access-Control-Allow-Origin"]
+		So(corsPresent, ShouldEqual, true)
+	})
+
 	Convey("it should return Holochain errors from call functions as 400", t, func() {
 		body := bytes.NewBuffer([]byte("2"))
 		resp, err := http.Post("http://0.0.0.0:31415/fn/jsSampleZome/addOdd", "", body)


### PR DESCRIPTION
Adds `Access-Control-Allow-Origin: *` to outgoing response headers for `/fn/` requests.

### Notes

CORS is a tricky issue, since it's all client-side enforced, from a server/node perspective, there's really no reason not to allow all origins. Though really, it would probably be good if the host could configure their desired allow origins. Let me know if this is ok for now, or if you want me to add the configuration.

FYI, i need this header to support requests from the `null` origin. I.e. a web page hosted from `file://`.

### Testing

Something in Hash is breaking for me on HEAD develop right now... but I am able to successfully run:

```
go test -v ./ui
```