### PR TITLE
changing make.bat to build.bat and added missing gx-go commands 

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,4 +1,10 @@
+go get -u github.com/whyrusleeping/gx
+go get -u github.com/whyrusleeping/gx-go
+gx-go get github.com/holochain/holochain-proto
+
 go get github.com\holochain\holochain-proto\cmd\hcdev
 go get github.com\holochain\holochain-proto\cmd\hcd
 go get github.com\holochain\holochain-proto\cmd\hcadmin
 go get github.com\holochain\holochain-proto\cmd\bs
+
+gx-go rewrite --undo


### PR DESCRIPTION
for correct package management.
make.bat makes you believe that you have make properly installed which may not be the case.
