### PR TITLE
Fix ipv6 localhost address not being parsed

### DIFF
--- a/cmd/bs/bs.go
+++ b/cmd/bs/bs.go
@@ -13,6 +13,7 @@ import (
 	"os/user"
 	"strings"
 	"time"
+	"github.com/whyrusleeping/go-logging"
 )
 
 const (
@@ -136,6 +137,7 @@ func h(w http.ResponseWriter, r *http.Request) {
 	var err error
 	log.Infof("%s: processing req:%s\n", r.Method, r.URL.Path)
 	path := strings.Split(r.URL.Path, "/")
+	r.RemoteAddr = strings.Replace(r.RemoteAddr, "[::1]", "127.0.0.1", -1)
 	if r.Method == "GET" {
 		if len(path) != 2 {
 			http.Error(w, "expecting path /<holochainid>", 400)


### PR DESCRIPTION
Hack in bs that replaces ipv6 localhost "[::1]" to ipv4 "127.0.0.1" so that bs can work on win10.